### PR TITLE
remove /n from the tmp models

### DIFF
--- a/columns_setup.sh
+++ b/columns_setup.sh
@@ -2,7 +2,7 @@
 mkdir -p $1/macros
 mkdir -p $1/models/tmp
 dbt run-operation fivetran_utils.generate_columns_macro --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/macros/get_$5_columns.sql
-echo "select *\nfrom {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql
+echo "select * from {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql
 echo "\n\n" >> $1/models/$2__$5.sql
 echo "        {{
             fivetran_utils.fill_staging_columns(


### PR DESCRIPTION
little fix -- currently the tmp models are initialized as:
`select *\nfrom {{ var('table_name') }}`

which requires you to go in and delete the problematic \n