### PR TITLE
automate the staging model files more :)

### DIFF
--- a/columns_setup.sh
+++ b/columns_setup.sh
@@ -3,10 +3,32 @@ mkdir -p $1/macros
 mkdir -p $1/models/tmp
 dbt run-operation fivetran_utils.generate_columns_macro --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/macros/get_$5_columns.sql
 echo "select * from {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql
-echo "\n\n" >> $1/models/$2__$5.sql
-echo "        {{
+echo "" >> $1/models/$2__$5.sql
+echo "with base as (
+
+    select * 
+    from {{ ref('$2__$5_tmp') }}
+
+),
+
+fields as (
+
+    select
+        {{
             fivetran_utils.fill_staging_columns(
                 source_columns=adapter.get_columns_in_relation(ref('$2__$5_tmp')),
                 staging_columns=get_$5_columns()
             )
-        }}" >> $1/models/$2__$5.sql
+        }}
+        
+    from base
+),
+
+final as (
+    
+    select 
+    -- rename here
+    from fields
+)
+
+select * from final" >> $1/models/$2__$5.sql


### PR DESCRIPTION
adds the following to each stg_model:
- `base` CTE with tmp model `ref`
- `fields` CTE encapsulating the columns macro
- `final` CTE for renaming columns in the model file instead of the macro


also removes the \n's (i just started new lines, since bash didn't expand \n properly)