### PR TITLE
add enabled_vars_one_true

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ This macro creates a dummy coalesce value based on the data type of the field. S
 * `column` (required): Field you are applying the dummy coalesce.
 
 ----
+### enabled_vars_one_true ([source](macros/enabled_vars_one_true.sql))
+This macro references a set of specified boolean variable and returns `true` if any variable value is equal to true.
+
+**Usage:**
+```sql
+{{ fivetran_utils.enabled_vars_one_true(vars=["using_department_table", "using_customer_table"]) }}
+```
+**Args:**
+* `vars` (required): Variable(s) you are referencing to return the declared variable value.
+
+----
+
 ### enabled_vars ([source](macros/enabled_vars.sql))
 This macro references a set of specified boolean variable and returns `false` if any variable value is equal to false.
 

--- a/macros/enabled_vars_one_true.sql
+++ b/macros/enabled_vars_one_true.sql
@@ -1,0 +1,13 @@
+{% macro enabled_vars_one_true(vars) %}
+
+{% for v in vars %}
+    
+    {% if var(v, False) == True %}
+    {{ return(True) }}
+    {% endif %}
+
+{% endfor %}
+
+{{ return(False) }}
+
+{% endmacro %}


### PR DESCRIPTION
This branch includes the following updates:
- Addition of the macro `enabled_vars_one_true` and accompanying documentation.

The `enabled_vars_one_true` macro is used in the [quickbooks sales_union intermediate model](https://github.com/fivetran/dbt_quickbooks/blob/sales_receipt_var/models/intermediate/int_quickbooks__sales_union.sql). The purpose of this macro is to run the model if one of the variables passed = `true`. If they all are false then the macro returns false and the model does not run.