### PR TITLE
Staging helper macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ This macro is intended to be used as a `run-operation` when generating Fivetran 
 
 **Usage:**
 ```bash
-dbt run-operation staging_models_automation --args '{package: asana, target_schema: asana_target, target_database: database-target-name, tables: ["user","tag"]}'
+dbt run-operation staging_models_automation --args '{package: asana, source_schema: asana_source, source_database: database-source-name, tables: ["user","tag"]}'
 ```
 
 **CLI Output:**
@@ -245,8 +245,8 @@ source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_asana_source' stg_asa
 
 **Args:**
 * `package`         (required): Name of the package for which you are creating staging models/macros.
-* `target_schema`   (required): Name of the target_schema from which the bash command will query.
-* `target_database` (required): Name of the target_database from which the bash command will query.
+* `source_schema`   (required): Name of the source_schema from which the bash command will query.
+* `source_database` (required): Name of the source_database from which the bash command will query.
 * `tables`          (required): List of the tables for which you want to create staging models/macros.
 
 ----

--- a/README.md
+++ b/README.md
@@ -229,6 +229,27 @@ It simply chooses which version of the data to seed (the Snowflake copy should c
 * `seed_name` (required): Name of the seed that has separate snowflake seed data.
 
 ----
+### staging_models_automation ([source](macros/staging_models_automation.sql))
+This macro is intended to be used as a `run-operation` when generating Fivetran dbt source package staging models/macros. This macro will receive user input to create all necessary ([bash commands](columns_setup.sh)) appended with `&&` so they may all be ran at once. The output of this macro within the CLI will then be copied and pasted as a command to generate the staging models/macros.
+
+**Usage:**
+```bash
+dbt run-operation staging_models_automation --args '{package: asana, target_schema: asana_target, target_database: database-target-name, tables: ["user","tag"]}'
+```
+
+**CLI Output:**
+```bash
+source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_asana_source' stg_asana dbt-package-testing asana_2 user && 
+source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_asana_source' stg_asana dbt-package-testing asana_2 tag
+```
+
+**Args:**
+* `package`         (required): Name of the package for which you are creating staging models/macros.
+* `target_schema`   (required): Name of the target_schema from which the bash command will query.
+* `target_database` (required): Name of the target_database from which the bash command will query.
+* `tables`          (required): List of the tables for which you want to create staging models/macros.
+
+----
 ### string_agg ([source](macros/string_agg.sql))
 This macro allows for cross database field aggregation and delimiter customization. Supported database specific field aggregation functions include 
 BigQuery, Snowflake, Redshift.

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+**What change does this PR introduce?** 
+<!--- Describe what you did and why. -->
+
+**If this PR introduces a new macro, how did you test the new macro?** 
+<!--- Describe how you tested the new macro code. -->
+
+**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
+<!--- List the packages the macro is in and how you tested the changes. -->
+
+**Did you update the README to reflect the macro addition/modifications?** 
+<!--- Mark yes or no. If no, provide a reason. -->
+- [ ] Yes
+- [ ] No (provide further explanation)

--- a/macros/staging_models_automation.sql
+++ b/macros/staging_models_automation.sql
@@ -1,10 +1,10 @@
-{% macro staging_models_automation(package, target_schema, target_database, tables) %}
+{% macro staging_models_automation(package, source_schema, source_database, tables) %}
 
 {% set package = ""~ package ~"" %}
-{% set target_schema = ""~ target_schema ~"" %}
-{% set target_database = ""~ target_database ~"" %}
+{% set source_schema = ""~ source_schema ~"" %}
+{% set source_database = ""~ source_database ~"" %}
 
-{% set zsh_command = "source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_"""~ package ~"""_source' stg_"""~ package ~""" """~ target_database ~""" """~ target_schema ~""" " %}
+{% set zsh_command = "source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_"""~ package ~"""_source' stg_"""~ package ~""" """~ source_database ~""" """~ source_schema ~""" " %}
 
 {% for t in tables %}
     {% if t != tables[-1] %}

--- a/macros/staging_models_automation.sql
+++ b/macros/staging_models_automation.sql
@@ -1,0 +1,21 @@
+{% macro staging_models_automation(package, target_schema, target_database, tables) %}
+
+{% set package = ""~ package ~"" %}
+{% set target_schema = ""~ target_schema ~"" %}
+{% set target_database = ""~ target_database ~"" %}
+
+{% set zsh_command = "source dbt_modules/fivetran_utils/columns_setup.sh '../dbt_"""~ package ~"""_source' stg_"""~ package ~""" """~ target_database ~""" """~ target_schema ~""" " %}
+
+{% for t in tables %}
+    {% if t != tables[-1] %}
+        {% set help_command = zsh_command + t + " && \n" %}
+    
+    {% else %}
+        {% set help_command = zsh_command + t %}
+
+    {% endif %}
+    {{ log(help_command, info=True) }}
+
+{% endfor %}
+
+{% endmacro %}


### PR DESCRIPTION
This PR includes the following changes:

- Addition of the `staging_models_automation` macro which allows for multiple bash commands to be generated within the CLI to create staging models/macros. This CLI output can then be copy/pasted to generate all necessary staging models/macros.
- Inclusion of accompanying `staging_models_automation` documentation.
- Addition of the `PULL_REQUEST_TEMPLATE.md` to be used when merged with master for the dbt_fivetran_utils PR template.