### PR TITLE
minor postgres fix

### DIFF
--- a/macros/array_agg.sql
+++ b/macros/array_agg.sql
@@ -5,13 +5,9 @@
 {%- endmacro %}
 
 {% macro default__array_agg(field_to_agg) %}
+    array_agg({{ field_to_agg }})
+{% endmacro %}
+
+{% macro redshift__array_agg(field_to_agg) %}
     listagg({{ field_to_agg }}, ',')
-{% endmacro %}
-
-{% macro snowflake__array_agg(field_to_agg) %}
-    array_agg({{ field_to_agg }})
-{% endmacro %}
-
-{% macro bigquery__array_agg(field_to_agg) %}
-    array_agg({{ field_to_agg }})
 {% endmacro %}


### PR DESCRIPTION
This PR includes the following update:

- Adjustment of the array_agg macro. It was originally thought that similar to redshift, postgres did not contain an array_agg function. However, it does and therefore the macro has been changed for the default to be array_agg and the exception to be redshift.