### PR TITLE
pivot json properties into columns macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ The data is returned by the path you provide as the argument. The json_extract m
 * `string_path`  (required): Name of the path in the json object which you want to extract the data from.
 
 ----
+### pivot_json_extract ([source](macros/pivot_json_extract.sql))
+This macro builds off of the `json_extract` macro in order to extract a list of fields from a json object and pivot the fields out into columns. The `pivot_json_extract` macro is compatible with BigQuery, Redshift, Postgres, and Snowflake.
+
+**Usage:**
+```sql
+{{ fivetran_utils.pivot_json_extract(string="json_value", list_of_properties=["field 1", "field 2"]) }}
+```
+**Args:**
+* `string` (required): Name of the field which contains the json object.
+* `list_of_properties`  (required): List of the fields that you want to extract from the json object and pivot out into columns. Any spaces will be replaced by underscores in column names.
+
+----
 ### max_bool ([source](macros/max_bool.sql))
 This macro allows for cross database use of obtaining the max boolean value of a field. This macro recognizes true = 1 and false = 0. The macro will aggregate the boolean_field and return the max boolean value. The max_bool macro is compatible with BigQuery, Redshift, Postgres, and Snowflake.
 

--- a/macros/passthru_columns.sql
+++ b/macros/passthru_columns.sql
@@ -1,0 +1,6 @@
+{% macro passthru_columns(columns=[]) %}
+
+{% if columns != [] -%},{% endif %}
+{{ columns | join(', ') }}
+
+{% endmacro %}

--- a/macros/passthru_columns.sql
+++ b/macros/passthru_columns.sql
@@ -1,6 +1,0 @@
-{% macro passthru_columns(columns=[]) %}
-
-{% if columns != [] -%},{% endif %}
-{{ columns | join(', ') }}
-
-{% endmacro %}

--- a/macros/pivot_json_extract.sql
+++ b/macros/pivot_json_extract.sql
@@ -1,8 +1,8 @@
 {% macro pivot_json_extract(string, list_of_properties) %}
 
-{% for property in list_of_properties -%}
-    replace( {{ fivetran_utils.json_extract(string, property) }}, '"', '')
-        as {{ property | replace(' ', '_') | lower }}
+{%- for property in list_of_properties -%}
+
+replace( {{ fivetran_utils.json_extract(string, property) }}, '"', '') as {{ property | replace(' ', '_') | lower }}
 
 {%- if not loop.last -%},{%- endif %}
 {% endfor -%}

--- a/macros/pivot_json_extract.sql
+++ b/macros/pivot_json_extract.sql
@@ -1,0 +1,10 @@
+{% macro pivot_json_extract(json, list_of_properties) %}
+
+{% for property in list_of_properties -%}
+    replace( {{ fivetran_utils.json_extract(string = json, string_path = property) }}, '"', '')
+        as {{ property | replace(' ', '_') | lower }}
+
+{%- if not loop.last -%},{%- endif %}
+{% endfor -%}
+
+{% endmacro %}

--- a/macros/pivot_json_extract.sql
+++ b/macros/pivot_json_extract.sql
@@ -1,7 +1,7 @@
-{% macro pivot_json_extract(json, list_of_properties) %}
+{% macro pivot_json_extract(string, list_of_properties) %}
 
 {% for property in list_of_properties -%}
-    replace( {{ fivetran_utils.json_extract(string = json, string_path = property) }}, '"', '')
+    replace( {{ fivetran_utils.json_extract(string, property) }}, '"', '')
         as {{ property | replace(' ', '_') | lower }}
 
 {%- if not loop.last -%},{%- endif %}


### PR DESCRIPTION
**What change does this PR introduce?** 
Creates a macro to replace this [mixpanel macro](https://github.com/fivetran/dbt_mixpanel/blob/master/macros/pivot_event_properties_json.sql). It extracts a list of fields from a json and pivots out the fields into columns.

**If this PR introduces a new macro, how did you test the new macro?** 
using mixpanel circle ci seed data

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
