### PR TITLE
spark quote columns

### DIFF
--- a/macros/fill_staging_columns.sql
+++ b/macros/fill_staging_columns.sql
@@ -19,7 +19,7 @@
 {% macro quote_column(column) %}
     {% if 'quote' in column %}
         {% if column.quote %}
-            {% if target.type == 'bigquery' %}
+            {% if target.type in ('bigquery', 'spark') %}
             `{{ column.name }}`
             {% elif target.type == 'snowflake' %}
             "{{ column.name | upper }}"


### PR DESCRIPTION
**What change does this PR introduce?** 
adds proper column quoting for spark

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
it's in all of them but this will only affect databricks warehouses, which our packages are not compatible with yet really 


**Did you update the README to reflect the macro addition/modifications?** 
- [ ] Yes
- [x] No -> the macro i changed (quote_columns in fill_staging_columns) isn't in the readme
