### PR TITLE
Freshness tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ than, or equal to, the specified numeric expression. The ceiling macro is compat
 
 ----
 ### collect_freshness ([source](macros/collect_freshness.sql))
-This macro overrides dbt's default [`collect_freshness` macro]((https://github.com/fishtown-analytics/dbt/blob/0.19.latest/core/dbt/include/global_project/macros/adapters/common.sql#L257-L273)) that is called when running `dbt source snapshot-freshness`. It allows you to incorporate model enabling/disabling variables into freshness tests, so that, if a source table does not exist, dbt will not run (and error on) a freshness test on the table. **Any package that has a dependency on fivetran_utils will use this version of the macro. If no `meta.is_enabled` field is provided, the `collect_freshness` should run exactly like dbt's default version.**
+This macro overrides dbt's default [`collect_freshness` macro](https://github.com/fishtown-analytics/dbt/blob/0.19.latest/core/dbt/include/global_project/macros/adapters/common.sql#L257-L273) that is called when running `dbt source snapshot-freshness`. It allows you to incorporate model enabling/disabling variables into freshness tests, so that, if a source table does not exist, dbt will not run (and error on) a freshness test on the table. **Any package that has a dependency on fivetran_utils will use this version of the macro. If no `meta.is_enabled` field is provided, the `collect_freshness` should run exactly like dbt's default version.**
 
 **Usage:**
 ```yml

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ than, or equal to, the specified numeric expression. The ceiling macro is compat
 * `num` (required): The integer field you wish to apply the ceiling function.
 
 ----
+### collect_freshness ([source](macros/collect_freshness.sql))
+This macro overrides dbt's default [`collect_freshness` macro]((https://github.com/fishtown-analytics/dbt/blob/0.19.latest/core/dbt/include/global_project/macros/adapters/common.sql#L257-L273)) that is called when running `dbt source snapshot-freshness`. It allows you to incorporate model enabling/disabling variables into freshness tests, so that, if a source table does not exist, dbt will not run (and error on) a freshness test on the table. **Any package that has a dependency on fivetran_utils will use this version of the macro. If no `meta.is_enabled` field is provided, the `collect_freshness` should run exactly like dbt's default version.**
+
+**Usage:**
+```yml
+# in the sources.yml
+sources:
+  - name: source_name
+    freshness:
+      warn_after: {count: 84, period: hour}
+      error_after: {count: 168, period: hour}
+    tables:
+      - name: table_that_might_not_exist
+        meta:
+          is_enabled: "{{ var('package__using_this_table', true) }}"
+```
+**Args (sorta):**
+* `meta.is_enabled` (optional): The variable(s) you would like to reference to determine if dbt should include this table in freshness tests.
+
+----
 ### dummy_coalesce_value ([source](macros/dummy_coalesce_value.sql))
 This macro creates a dummy coalesce value based on the data type of the field. See below for the respective data type and dummy values:
 - String    = 'DUMMY_STRING'

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -15,7 +15,6 @@
     {% endif %}
   {% endfor %}
   {% set is_enabled = (enabled_array != []) %}
-  {{ log(is_enabled, info=true) }}
 
     select
       {% if is_enabled %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -1,0 +1,36 @@
+{% macro collect_freshness(source, loaded_at_field, filter) %}
+  {{ return(adapter.dispatch('collect_freshness')(source, loaded_at_field, filter))}}
+{% endmacro %}
+
+
+{% macro default__collect_freshness(source, loaded_at_field, filter) %}
+  {% call statement('collect_freshness', fetch_result=True, auto_begin=False) -%}
+
+  {%- set enabled_array = [] -%}
+  {% for node in graph.sources.values() %}
+    {% if node.name == source.name %}
+      {% if node.meta['is_enabled'] %}
+        {%- do enabled_array.append(1) -%}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+  {% set is_enabled = (enabled_array != []) %}
+  {{ log(is_enabled, info=true) }}
+
+    select
+      {% if is_enabled %}
+      max({{ loaded_at_field }})
+      {% else %} 
+      {{ current_timestamp() }} {% endif %} as max_loaded_at,
+      {{ current_timestamp() }} as snapshotted_at
+
+    {% if is_enabled %}
+    from {{ source }}
+      {% if filter %}
+      where {{ filter }}
+      {% endif %}
+    {% endif %}
+
+  {% endcall %}
+  {{ return(load_result('collect_freshness').table) }}
+{% endmacro %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -9,7 +9,7 @@
   {%- set enabled_array = [] -%}
   {% for node in graph.sources.values() %}
     {% if node.name == source.name %}
-      {% if node.meta['is_enabled'] %}
+      {% if node.meta['is_enabled'] is true or node.meta['is_enabled'] is None %}
         {%- do enabled_array.append(1) -%}
       {% endif %}
     {% endif %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -9,7 +9,7 @@
   {%- set enabled_array = [] -%}
   {% for node in graph.sources.values() %}
     {% if node.name == source.name %}
-      {% if node.meta['is_enabled'] == true or node.meta['is_enabled'] == none %}
+      {% if (node.meta['is_enabled'] | default(true)) %}
         {%- do enabled_array.append(1) -%}
       {% endif %}
     {% endif %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -9,7 +9,7 @@
   {%- set enabled_array = [] -%}
   {% for node in graph.sources.values() %}
     {% if node.name == source.name %}
-      {% if node.meta['is_enabled'] is true or node.meta['is_enabled'] is None %}
+      {% if node.meta['is_enabled'] == true or node.meta['is_enabled'] == none %}
         {%- do enabled_array.append(1) -%}
       {% endif %}
     {% endif %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
A `collect_freshness` macro to override [dbt's default freshness test](https://github.com/fishtown-analytics/dbt/blob/0.19.latest/core/dbt/include/global_project/macros/adapters/common.sql#L257-L273). This will allow us to incorporate any source-disabling variables so that `dbt source snapshot-freshness` does not fail due to these tables not existing. To disable the source `contact` table in hubspot, we'd add the following sort of `is_enabled` config to the packages source.yml
```yml
sources:
  - name: hubspot
    freshness:
      warn_after: {count: 84, period: hour}
      error_after: {count: 168, period: hour}
    tables:
      - name: contact
        meta:
          is_enabled: "{{ var('hubspot_marketing_enabled', true) and var('hubspot_contact_enabled', true) }}"
```

Addresses issues like https://github.com/fivetran/dbt_zendesk_source/issues/10 and https://github.com/fivetran/dbt_hubspot/issues/41. We can't use the solution put forth there, as the `sources` config block in a project's `dbt_project.yml` file would not capture the value of any referenced variable. It would always just automatically use the default value for the variable, since dbt thinks the variable = None at this point in execution. so it was basically hard-coding the source `+enabled` property to false and was not dynamically referring to any variable.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
I tested it on Hubspot contact [data](https://github.com/fivetran/dbt_hubspot_source/blob/master/integration_tests/data/contact_data.csv), from a root dbt project that installed `hubspot_source` as a package. 

I ran `dbt source snapshot-freshness --select hubspot.contact` after setting the `hubspot_marketing_enabled` and/or `hubspot_contact_enabled` variables to false in my root `dbt_project.yml`. I did so after completely dropping the source table from my hubspot_schema as well, which did not cause freshness test issues when `hubspot_marketing_enabled` or `hubspot_contact_enabled` were set to false 

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
I also tested this out on the `fivetran_log` package -- sometimes `trigger_table` and/or `transformation` are missing if customers don't use fivetran transformations. I did the same thing I did with hubspot -- ran freshness tests before and after setting `fivetran_log_using_triggers` to false.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [X] Yes 
- [ ] No (provide further explanation)
