### PR TITLE
Fixed: union_data macro situation when relation does not exist

### DIFF
--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -18,7 +18,7 @@
         identifier=table_identifier
     ) -%}
     
-    {% set relation_exists=relation is not none  %}
+    {% set relation_exists=relation is not none %}
 
     {% if relation_exists %}
 

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -17,8 +17,14 @@
         schema=schema,
         identifier=table_identifier
     ) -%}
+    
+    {% set relation_exists=relation is not none  %}
+
+    {% if relation_exists %}
 
     {% do relations.append(relation) %}
+    
+    {% endif %}
 
     {% endfor %}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
Fixes `dbt run` and `dbt docs generate` for situations when relation/table does not exist in one of unioned schemas.<br>
Table existance logic taken from [Writing packages when a source table may or may not exist](https://discourse.getdbt.com/t/writing-packages-when-a-source-table-may-or-may-not-exist/1487)

Example `dbt run` error when `order_adjustment` table does not exist in one of the schemas
```
11:27:02 | 5 of 31 START view model dbt_dj_stg_shopify.stg_shopify__order_adjustment_tmp [RUN]
11:27:04 | 5 of 31 ERROR creating view model dbt_dj_stg_shopify.stg_shopify__order_adjustment_tmp [ERROR in 1.73s]
Compilation Error in model stg_shopify__order_adjustment_tmp (models/tmp/stg_shopify__order_adjustment_tmp.sql)
  Macro union_relations expected a Relation but received the value: None
  
  > in macro _is_relation (macros/cross_db_utils/_is_relation.sql)
  > called by macro default__union_relations (macros/sql/union.sql)
  > called by macro union_relations (macros/sql/union.sql)
  > called by macro default__union_data (macros/union_data.sql)
  > called by macro union_data (macros/union_data.sql)
  > called by model stg_shopify__order_adjustment_tmp (models/tmp/stg_shopify__order_adjustment_tmp.sql)
  > called by model stg_shopify__order_adjustment_tmp (models/tmp/stg_shopify__order_adjustment_tmp.sql)
```

`dbt docs generate` just never finishes, spinning forever on `stg_shopify__order_adjustment_tmp`

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
none

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [x] No (it's just a bugfix)
