### PR TITLE
default get_columns_macro fix

### DIFF
--- a/macros/get_columns_for_macro.sql
+++ b/macros/get_columns_for_macro.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__get_columns_for_macro(table_name, schema_name, database_name=target.database) %}
+{% macro default__get_columns_for_macro(table_name, schema_name, database_name=target.database) %}
 
 {% set query %}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Fixes an issue with the `get_columns_macro` that only shows on `dbt v0.19.2`. There was no default config for the macro previously. This PR overrides the snowflake config to be the default config going forward.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
N/A

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
N/A

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)
No README update necessary as this is a bug fix
