### PR TITLE
Fix/postgres timstamp diff

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils'
-version: '0.2.2'
+version: '0.2.4'
 config-version: 2
 
 source-paths: ["models"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.2.2'
+version: '0.2.4'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/timestamp_diff.sql
+++ b/macros/timestamp_diff.sql
@@ -34,7 +34,7 @@
 
 {% endmacro %}
 
-{% macro postgres__datediff(first_date, second_date, datepart) %}
+{% macro postgres__timestamp_diff(first_date, second_date, datepart) %}
 
     {% if datepart == 'year' %}
         (date_part('year', ({{second_date}})::date) - date_part('year', ({{first_date}})::date))


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Fivetran created PR that introduces a fix to the `timestamp_diff` macro where a holdover of `date_diff` still existed in the dispatch for postgres.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
N/A

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
This PR has been tested on the dbt 0.20.0 zendesk package.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)
No logic changes were implemented that would require the README to be edited