### PR TITLE
fixing add_pass_through_columns macro

### DIFF
--- a/macros/add_pass_through_columns.sql
+++ b/macros/add_pass_through_columns.sql
@@ -4,7 +4,15 @@
 
     {% for column in pass_through_var %}
 
-      {% do base_columns.append({ "name": column.name, "alias": column.alias }) if column.alias else base_columns.append({ "name": column.name }) %}
+      {% if column.alias %}
+
+      {% do base_columns.append({ "name": column.name, "alias": column.alias, "datatype": column.datatype if column.datatype else dbt_utils.type_string()}) %}
+
+      {% else %}
+
+      {% do base_columns.append({ "name": column.name, "datatype": column.datatype if column.datatype else dbt_utils.type_string()}) %}
+        
+      {% endif %}
 
     {% endfor %}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
For instances where the source table does not include the additional pass through columns indicated in the project.yml file, the `fill_staging_columns()` macro will fail, specifically line 6-12: 
```
{% if column.name|lower in source_column_names -%}
    {{ fivetran_utils.quote_column(column) }} as 
    {%- if 'alias' in column %} {{ column.alias }} {% else %} {{ fivetran_utils.quote_column(column) }} {%- endif -%}
{%- else -%}
    cast(null as {{ column.datatype }})
    {%- if 'alias' in column %} as {{ column.alias }} {% else %} as {{ fivetran_utils.quote_column(column) }} {% endif -%}
{%- endif -%} 
```

This is because the pass through columns do not specify datatype and will result in compiled sql like `cast(null as )` which will fail. Modification of the `add_pass_through_columns` macro will allow for the addition of a datatype key in the project.yml  or use string as the default.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
* tested in dbt_hubspot_source

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [x] No (provide further explanation)
