### PR TITLE
Feature/add passthrough update

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils'
-version: '0.2.5'
+version: '0.2.6'
 config-version: 2
 
 source-paths: ["models"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.2.5'
+version: '0.2.6'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/add_pass_through_columns.sql
+++ b/macros/add_pass_through_columns.sql
@@ -4,7 +4,15 @@
 
     {% for column in pass_through_var %}
 
-      {% do base_columns.append({ "name": column.name, "alias": column.alias }) if column.alias else base_columns.append({ "name": column.name }) %}
+      {% if column.alias %}
+
+      {% do base_columns.append({ "name": column.name, "alias": column.alias, "datatype": column.datatype if column.datatype else dbt_utils.type_string()}) %}
+
+      {% else %}
+
+      {% do base_columns.append({ "name": column.name, "datatype": column.datatype if column.datatype else dbt_utils.type_string()}) %}
+        
+      {% endif %}
 
     {% endfor %}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
This PR adds the functionality to the `add_passthrough_columns` macro to allow for fields that do not exist to be included and set as a datatype. If the datatype is not set then it will default to string.

@jamesrayoub (the original creator of the PR #42) detailed the reason for this update:

> The reason for this PR is due to the fact that I'm trying to replicate the production models in a staging environment using staging instances of our tools which don't always have all of the same custom fields as in production; i.e. not every new custom field was tested in staging before creating in prod.


**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
This was tested using the dbt_hubspot_source package.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
- hubpost
- klaviyo
- pendo

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)

Edits to this README are not needed.