### PR TITLE
Add ability to pass an array as a string to the union_data macro

### DIFF
--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -9,6 +9,13 @@
 {% if var('union_schemas', none) %}
 
     {% set relations = [] %}
+    
+    {% if var('union_schemas') is string %}
+    {% set trimmed = var('union_schemas')|trim('[')|trim(']') %}
+    {% set schemas = trimmed.split(',')|map('trim'," ")|map('trim','"')|map('trim',"'") %}
+    {% else %}
+    {% set schemas = var('union_schemas') %}
+    {% endif %}
 
     {% for schema in var('union_schemas') %}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Users have requested the ability to [dynamically generate schema lists for the `union_data` macro](https://github.com/fivetran/dbt_shopify/issues/25). Currently, this doesn't work because the macro gets passed the array of schemas as a string instead of as an array. 

This PR adds functionality to the macro so that we can parse the string and use it in the macro.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
Tested it out within the Shopify package on my local machine.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No, changes not necessary.
