### PR TITLE
Release/v0.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_modules/
 logs/
+venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt_fivetran_utils v0.2.9
 
-## Bug Fix
+## Bug Fixes
 - Added a specific Snowflake macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))
     - This Snowflake version of the macro includes a `try_parse_json` function within the `json_extract_path` function. This allows for the macro to succeed if not all fields are a json object that are being passed through. If a field is not a json object, then a `null` record is generated. 
 - Updated the Redshift macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# dbt_fivetran_utils v0.2.8
+# dbt_fivetran_utils v0.2.9
 
 ## 🚨 Breaking Changes
 - n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # dbt_fivetran_utils v0.2.9
 
-## Under the Hood
+## Bug Fix
 - Added a specific Snowflake macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))
     - This Snowflake version of the macro includes a `try_parse_json` function within the `json_extract_path` function. This allows for the macro to succeed if not all fields are a json object that are being passed through. If a field is not a json object, then a `null` record is generated. 
 - Updated the Redshift macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))
     - Similar to the above, Redshift cannot parse the field if every record is not a json object. This update converts a non-json field to `null` so the function does not fail.
+
+## Under the Hood
+- Included a `union_schema_variable` and a `union_database_variable` which will allow the `source_relation` and `union_data` macros to be used with varying variable names. ([#49](https://github.com/fivetran/dbt_fivetran_utils/pull/49))
+    - This allows for dbt projects that are utilizing more than one dbt package with the union source feature to have different names and not see duplicate variable name errors.
+    - This change needs to be applied at the package level to account for the variable name change. If this is not set, the macros looks for either `union_schemas` or `union_databases` variables.
 
 # dbt_fivetran_utils v0.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # dbt_fivetran_utils v0.2.9
 
-## 🚨 Breaking Changes
-- n/a
+## Under the Hood
+- Added a specific Snowflake macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))
+    - This Snowflake version of the macro includes a `try_parse_json` function within the `json_extract_path` function. This allows for the macro to succeed if not all fields are a json object that are being passed through. If a field is not a json object, then a `null` record is generated. 
+- Updated the Redshift macro designation for the `json_extract_path` macro. ([#50](https://github.com/fivetran/dbt_fivetran_utils/pull/50))
+    - Similar to the above, Redshift cannot parse the field if every record is not a json object. This update converts a non-json field to `null` so the function does not fail.
 
-## Bug Fixes
-- n/a
+# dbt_fivetran_utils v0.2.8
 
 ## Features
 - Added this changelog to capture iterations of the package!
 - Added the `add_dbt_source_relation()` macro, which passes the `dbt_source_relation` column created by `union_data()` to `source_relations()` in package staging models. See the README for more details on its appropriate usage.
-
-## Under the Hood
-- n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Under the Hood
 - Included a `union_schema_variable` and a `union_database_variable` which will allow the `source_relation` and `union_data` macros to be used with varying variable names. ([#49](https://github.com/fivetran/dbt_fivetran_utils/pull/49))
-    - This allows for dbt projects that are utilizing more than one dbt package with the union source feature to have different names and not see duplicate variable name errors.
+    - This allows for dbt projects that are utilizing more than one dbt package with the union source feature to have different variable names and not see duplicate errors.
     - This change needs to be applied at the package level to account for the variable name change. If this is not set, the macros looks for either `union_schemas` or `union_databases` variables.
 
 # dbt_fivetran_utils v0.2.8

--- a/README.md
+++ b/README.md
@@ -462,6 +462,8 @@ When using this functionality, every `_tmp` table should use this macro as descr
 * `default_database`: The default database where source data should be found. This is used when unioning schemas.
 * `default_schema`: The default schema where source data should be found. This is used when unioning databases.
 * `default_variable`: The name of the variable that users should populate when they want to pass one specific relation to this model (mostly used for CI)
+* `union_schema_variable` (optional): The name of the union schema variable. By default the macro will look for `union_schemas`.
+* `union_database_variable` (optional): The name of the union database variable. By default the macro will look for `union_databases`.
 
 ----
 ### source_relation ([source](macros/source_relation.sql))
@@ -472,6 +474,10 @@ It should be added to all non-tmp staging models when using the `union_data` mac
 ```sql
 {{ fivetran_utils.source_relation() }}
 ```
+
+**Args:**
+* `union_schema_variable` (optional): The name of the union schema variable. By default the macro will look for `union_schemas`.
+* `union_database_variable` (optional): The name of the union database variable. By default the macro will look for `union_databases`.
 
 ### add_dbt_source_relation ([source](macros/add_dbt_source_relation.sql))
 This macro is intended to be used within the second CTE (typically named `fields`) of non-tmp staging models. 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils'
-version: '0.2.8'
+version: '0.2.9'
 config-version: 2
 
 source-paths: ["models"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.2.8'
+version: '0.2.9'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/json_extract.sql
+++ b/macros/json_extract.sql
@@ -10,9 +10,15 @@
  
 {% endmacro %}
 
+{% macro snowflake__json_extract(string, string_path) %}
+
+  json_extract_path_text(try_parse_json( {{string}} ), {{ "'" ~ string_path ~ "'" }} )
+
+{% endmacro %}
+
 {% macro redshift__json_extract(string, string_path) %}
 
-  json_extract_path_text({{string}}, {{ "'" ~ string_path ~ "'" }} )
+  case when is_valid_json( {{string}} ) then json_extract_path_text({{string}}, {{ "'" ~ string_path ~ "'" }} ) else null end
  
 {% endmacro %}
 

--- a/macros/source_relation.sql
+++ b/macros/source_relation.sql
@@ -1,20 +1,20 @@
-{% macro source_relation() -%}
+{% macro source_relation(union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
-{{ adapter.dispatch('source_relation', 'fivetran_utils') () }}
+{{ adapter.dispatch('source_relation', 'fivetran_utils') (union_schema_variable, union_database_variable) }}
 
 {%- endmacro %}
 
-{% macro default__source_relation() %}
+{% macro default__source_relation(union_schema_variable, union_database_variable) %}
 
-{% if var('union_schemas', none)  %}
+{% if var(union_schema_variable, none)  %}
 , case
-    {% for schema in var('union_schemas') %}
+    {% for schema in var(union_schema_variable) %}
     when lower(replace(replace(_dbt_source_relation,'"',''),'`','')) like '%.{{ schema|lower }}.%' then '{{ schema|lower }}'
     {% endfor %}
   end as source_relation
-{% elif var('union_databases', none) %}
+{% elif var(union_database_variable, none) %}
 , case
-    {% for database in var('union_databases') %}
+    {% for database in var(union_database_variable) %}
     when lower(replace(replace(_dbt_source_relation,'"',''),'`','')) like '%{{ database|lower }}.%' then '{{ database|lower }}'
     {% endfor %}
   end as source_relation

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -1,23 +1,41 @@
-{% macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable) -%}
+{% macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
-{{ adapter.dispatch('union_data', 'fivetran_utils') (table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable) }}
+{{ adapter.dispatch('union_data', 'fivetran_utils') (
+    table_identifier, 
+    database_variable, 
+    schema_variable, 
+    default_database, 
+    default_schema, 
+    default_variable,
+    union_schema_variable,
+    union_database_variable
+    ) }}
 
 {%- endmacro %}
 
-{% macro default__union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable) %}
+{% macro default__union_data(
+    table_identifier, 
+    database_variable, 
+    schema_variable, 
+    default_database, 
+    default_schema, 
+    default_variable,
+    union_schema_variable,
+    union_database_variable
+    ) %}
 
-{% if var('union_schemas', none) %}
+{% if var(union_schema_variable, none) %}
 
     {% set relations = [] %}
-
-    {% if var('union_schemas') is string %}
-    {% set trimmed = var('union_schemas')|trim('[')|trim(']')|trim('(')|trim(')') %}
+    
+    {% if var(union_schema_variable) is string %}
+    {% set trimmed = var(union_schema_variable)|trim('[')|trim(']') %}
     {% set schemas = trimmed.split(',')|map('trim'," ")|map('trim','"')|map('trim',"'") %}
     {% else %}
-    {% set schemas = var('union_schemas') %}
+    {% set schemas = var(union_schema_variable) %}
     {% endif %}
 
-    {% for schema in schemas %}
+    {% for schema in var(union_schema_variable) %}
 
     {% set relation=adapter.get_relation(
         database=var(database_variable, default_database),
@@ -37,11 +55,11 @@
 
     {{ dbt_utils.union_relations(relations) }}
 
-{% elif var('union_databases', none) %}
+{% elif var(union_database_variable, none) %}
 
     {% set relations = [] %}
 
-    {% for database in var('union_databases') %}
+    {% for database in var(union_database_variable) %}
 
     {% set relation=adapter.get_relation(
         database=database,


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
This is the release branch for `v0.2.9` of dbt_fivetran_utils. Included PRs are below:
- PR #49 
- PR #50 

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
See the above PRs for more information. In summary the respective PRs do the following:
- PR 49: Applies an update to the union ability macro which allows an argument to be passed through to specific the source. This will allow for easier use of the macro if more than one platform source is being unioned.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
Modifications to the below macros. These have been properly tested in the Shopify and Fivetran_Log packages.
- `json_extract_path`
- `union_data`

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)

These were under the hood updates that do not need a README update to reflect the changes. The CHANGELOG has been updated for these accordingly.