### PR TITLE
collect freshness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_fivetran_utils v0.3.2
+## Fixes
+- The `collect_freshness` macro was inadvertently causing non-package source freshness tests that were aliased with the `identifier` config to use the current date opposed to the loaded date. Therefore, the macro was adjusted to leverage the table identifier opposed to the name. As the identifier is the name of the table by default, this should resolve the error. ([#56](https://github.com/fivetran/dbt_fivetran_utils/pull/56))
 # dbt_fivetran_utils v0.3.1
 ## Bug Fixes
 - Updates `staging_models_automation` macro to refer to dbt_packages instead of dbt_modules re: dbt v1.0.0 updates

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.3.1'
+version: '0.3.2'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.3.1'
+version: '0.3.2'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -19,9 +19,8 @@
     select
       {% if is_enabled %}
       max({{ loaded_at_field }})
-      {{ current_timestamp() }}
       {% else %} 
-      max({{ loaded_at_field }}) {% endif %} as max_loaded_at,
+      {{ current_timestamp() }} {% endif %} as max_loaded_at,
       {{ current_timestamp() }} as snapshotted_at
 
     {% if is_enabled %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -8,7 +8,7 @@
 
   {%- set enabled_array = [] -%}
   {% for node in graph.sources.values() %}
-    {% if node.name == source.name %}
+    {% if node.identifier == source.identifier %}
       {% if (node.meta['is_enabled'] | default(true)) %}
         {%- do enabled_array.append(1) -%}
       {% endif %}
@@ -17,10 +17,10 @@
   {% set is_enabled = (enabled_array != []) %}
 
     select
-      {% if is_enabled %}
-      max({{ loaded_at_field }})
+      {% if is_enabled == false %}
+      {{ current_timestamp() }}
       {% else %} 
-      {{ current_timestamp() }} {% endif %} as max_loaded_at,
+      max({{ loaded_at_field }}) {% endif %} as max_loaded_at,
       {{ current_timestamp() }} as snapshotted_at
 
     {% if is_enabled %}

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -17,7 +17,8 @@
   {% set is_enabled = (enabled_array != []) %}
 
     select
-      {% if is_enabled == false %}
+      {% if is_enabled %}
+      max({{ loaded_at_field }})
       {{ current_timestamp() }}
       {% else %} 
       max({{ loaded_at_field }}) {% endif %} as max_loaded_at,


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Fivetran created PR

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
This PR adjusts the `collect_freshness` macro to now refer to the `identifier` instead of the `name` of the node in the src.yml. This ensures if a dbt user has the `identifier` field populated, then the macro will work as intended. This has a high impact since this macro affects non Fivetran dbt packages. We will want to ensure this approach is a solid fix before merging. 

Additionally, we will most likely want to take a different approach to disabling freshness tests in our packages. The current solution is a too invasive and impacts parts of dbt projects that are outside the scope of Fivetran packages. We should use [this](https://github.com/dbt-labs/dbt-core/issues/4525) issue as inspiration for determining alternative approaches to freshness tests.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
All source freshness tests that exist in users dbt projects if they have a Fivetran dbt package installed.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)

This is an under the hood update and does not need a README update.
