### PR TITLE
Releases/v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_fivetran_utils v0.3.6
+## 🎉 Features 🎉 
+- New macro `get_column_names_only` that further automates the staging model creation to prefill column fields in the final select statement. 
+- Updated bash script `generate_models` to incorporate this new macro.
 # dbt_fivetran_utils v0.3.5
 ## 🎉 Features 🎉 
 - The `try_cast` macro has been added. This macro will try to cast the field to the specified datatype. If it cannot be cast, then a `null` value is provided. Please note, Postgres and Redshift destinations are only compatible with try_cast and the numeric datatype.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ dispatch:
 
 - [Automations](#automations)
   - [generate_columns_macro](#generate_columns_macro-source)
+  - [get_column_names_only](#get_column_names_only-source)
   - [get_columns_for_macro](#get_columns_for_macro-source)
   - [generate_docs](#generate_docs-source)
   - [staging_models_automation](#staging_models_automation-source)

--- a/README.md
+++ b/README.md
@@ -519,6 +519,37 @@ source dbt_packages/fivetran_utils/generate_docs.sh '../dbt_apple_search_ads_sou
 * `package` (required): Name of the package; include whether package is source or not
 
 ----
+### get_column_names_only ([source](macros/get_column_names_only.sql))
+This macro is used in the `generate_models.sh` script to further the `staging_models_automation` macro. This macro outputs all columns from the specified table, allowing `generate_models.sh` to prefill column fields in the final select statement.
+
+Note this will retain the timestamp from the built-in formatting update from dbt 1.0.0. Therefore in the staging model resulting from `generate_models.sh`, you will need to manually delete the timestamp.
+
+**Usage:**
+```bash
+dbt run-operation get_column_names_only --args '{table_name: [table_name], schema_name: [schema_name], database_name: [database_name]}' | tail -n +2 
+
+```
+**CLI Output:**
+```bash
+14:41:40      _fivetran_synced,
+    connector_id,
+    event,
+    id,
+    message_data,
+    message_event,
+    process_id,
+    sequence_number,
+    sync_id,
+    time_stamp,
+    transformation_id
+
+```
+**Args:**
+* `table_name`    (required): Name of the table you are wanting to return column names and datatypes.
+* `schema_name`   (required): Name of the schema where the above mentioned table resides.
+* `database_name` (optional): Name of the database where the above mentioned schema and table reside. By default this will be your target.database.
+
+----
 ### get_columns_for_macro ([source](macros/get_columns_for_macro.sql))
 This macro returns all column names and datatypes for a specified table within a database and is used as part of the [generate_columns_macro](macros/generate_columns_macro.sql).
 
@@ -648,7 +679,7 @@ The bash script does the following:
 This bash file can be used to setup or update packages to use the `generate_models` macro above. The bash script assumes that there already exists a macro directory with all relevant `get_<table_name>_columns.sql` files created. The bash script does the following:
 
 * Creates a `..._tmp.sql` file in the `models/tmp` directory and fills it with a `select * from {{ var('table_name') }}` where `table_name` is the name of the source table.
-* Creates or updates a `.sql` file in the `models` directory and fills it with the filled out version of the `fill_staging_columns` macro as shown above. You can then write whatever SQL you want around the macro to finishing off the staging file.
+* Creates or updates a `.sql` file in the `models` directory and fills it with the filled out version of the `fill_staging_columns` macro. The final select statement then grabs the output of the `get_column_names_only` macro.
 
 ```bash
 source dbt_packages/fivetran_utils/generate_models.sh "path/to/directory" file_prefix database_name schema_name table_name
@@ -661,4 +692,4 @@ source dbt_packages/fivetran_utils/generate_models.sh '../dbt_apple_search_ads_s
 
 With the above example, the script will:
 * Create a `stg_apple_search_ads__campaign_history_tmp.sql` file in the `models/tmp` directory, with `select * from {{ var('campaign_history') }}` in it.
-* Create or update a `stg_apple_search_ads__campaign_history.sql` file in the `models` directory with the pre-filled out `fill_staging_columns` macro.
+* Create or update a `stg_apple_search_ads__campaign_history.sql` file in the `models` directory with the pre-filled out `fill_staging_columns` macro, and fields in the final select statement resulting from the `get_column_names_only` macro.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.3.5'
+version: '0.3.6'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-mkdir -p $1/models/tmp #  the $ number signs reference the arguments in the staging_models_automation.sql file line 8
-dbt run-operation fivetran_utils.get_column_names_only --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/models/tmp/$2__$5_columns.sql 
-# dbt run-operation get_column_names_only --args '{table_name: log, schema_name: fivetran_log, database_name: dbt-package-testing}' >> fivetran_log/models/log__log_temp.sql 
+mkdir -p $1/models/tmp 
 echo "select * from {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql 
 echo "" > $1/models/$2__$5.sql
+
 echo "with base as (
+
     select * 
     from {{ ref('$2__$5_tmp') }}
 ),
+
 fields as (
+
     select
         {{
             fivetran_utils.fill_staging_columns(
@@ -16,16 +18,20 @@ fields as (
                 staging_columns=get_$5_columns()
             )
         }}
-        
     from base
 ),
+
 final as (
     
-    select 
-    " >> $1/models/$2__$5.sql
+    select " >> $1/models/$2__$5.sql
     
-$1/models/tmp/$2__$5_columns.sql >> $1/models/$2__$5.sql
+
+dbt run-operation fivetran_utils.get_column_names_only --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 >> $1/models/$2__$5.sql
     
-echo "from fields
+    
+echo "    from fields
 )
-select * from final" >> $1/models/$2__$5.sql
+
+select *
+from final" >> $1/models/$2__$5.sql
+

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -24,7 +24,7 @@ final as (
     select 
     " >> $1/models/$2__$5.sql
     
-sed "1p;d" $1/models/tmp/$2__$5_columns.sql >> $1/models/$2__$5.sql
+$1/models/tmp/$2__$5_columns.sql >> $1/models/$2__$5.sql
     
 echo "from fields
 )

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
-mkdir -p $1/models/tmp
-echo "select * from {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql
+mkdir -p $1/models/tmp #  the $ number signs reference the arguments in the staging_models_automation.sql file line 8
+dbt run-operation fivetran_utils.get_column_names_only --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/models/tmp/$2__$5_columns.sql 
+# dbt run-operation get_column_names_only --args '{table_name: log, schema_name: fivetran_log, database_name: dbt-package-testing}' >> fivetran_log/models/log__log_temp.sql 
+echo "select * from {{ var('$5') }}" > $1/models/tmp/$2__$5_tmp.sql 
 echo "" > $1/models/$2__$5.sql
 echo "with base as (
-
     select * 
     from {{ ref('$2__$5_tmp') }}
-
 ),
-
 fields as (
-
     select
         {{
             fivetran_utils.fill_staging_columns(
@@ -21,12 +19,13 @@ fields as (
         
     from base
 ),
-
 final as (
     
     select 
-    -- rename here
-    from fields
+    " >> $1/models/$2__$5.sql
+    
+sed "1p;d" $1/models/tmp/$2__$5_columns.sql >> $1/models/$2__$5.sql
+    
+echo "from fields
 )
-
 select * from final" >> $1/models/$2__$5.sql

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.3.5'
+version: '0.3.6'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/get_column_names_only.sql
+++ b/macros/get_column_names_only.sql
@@ -1,0 +1,47 @@
+{% macro default_get_column_names_only(table_name, schema_name, database_name=target.database) %}
+
+{% set query %}
+
+select
+    lower(column_name)
+from {{ database_name }}.information_schema.columns
+where lower(table_name) = '{{ table_name }}'
+and lower(table_schema) = '{{ schema_name }}'
+order by 1
+
+{% endset %}
+
+{% set results = run_query(query) %}
+{% set results_list = results.columns[0].values() %}}
+
+{{ return(results_list) }} 
+
+{% endmacro %}
+
+
+
+{% macro bigquery__get_column_names_only(table_name, schema_name, database_name=target.database) %}
+
+{% set query %}
+
+select
+    lower(column_name)
+from `{{ database_name }}`.{{ schema_name }}.INFORMATION_SCHEMA.COLUMNS
+where lower(table_name) = '{{ table_name }}'
+and lower(table_schema) = '{{ schema_name }}'
+order by 1
+
+{% endset %}
+
+{% set results = run_query(query) %}
+{% set results_list = results.columns[0].values() %}}
+{{ log(results_list, info=True)}} 
+{{ return(results_list) }}
+
+{% endmacro %}
+
+
+
+{% macro get_column_names_only(table_name, schema_name, database_name) -%}
+{{ return(adapter.dispatch('get_column_names_only')(table_name, schema_name, database_name)) }}
+{%- endmacro %}

--- a/macros/get_column_names_only.sql
+++ b/macros/get_column_names_only.sql
@@ -14,7 +14,7 @@ order by 1
 {% set results = run_query(query) %}
 {% set results_list = results.columns[0].values() %}}
 {% for col in results_list %}
-{% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
+{% do jinja_macro.append('        ' ~ col ~ (',' if not loop.last)) %}
 {% endfor %}
 
 {% if execute %}
@@ -46,7 +46,7 @@ order by 1
 {% set results = run_query(query) %}
 {% set results_list = results.columns[0].values() %}}
 {% for col in results_list %}
-{% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
+{% do jinja_macro.append('        ' ~ col ~ (',' if not loop.last)) %}
 {% endfor %}
 
 {% if execute %}
@@ -65,13 +65,3 @@ order by 1
 {% macro get_column_names_only(table_name, schema_name, database_name) -%}
 {{ return(adapter.dispatch('get_column_names_only')(table_name, schema_name, database_name)) }}
 {%- endmacro %}
-
-
--- % macro get_column_names_only_format(table_name, schema_name, database_name=target.database) -%}
--- {% set columns = get_column_names_only(table_name, schema_name, database_name) %}
-
--- {% for col in columns %}
--- {% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
--- {% endfor %}
-
--- {% endmacro %}

--- a/macros/get_column_names_only.sql
+++ b/macros/get_column_names_only.sql
@@ -13,6 +13,15 @@ order by 1
 
 {% set results = run_query(query) %}
 {% set results_list = results.columns[0].values() %}}
+{% for col in results_list %}
+{% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
+{% endfor %}
+
+{% if execute %}
+    {% set joined = jinja_macro | join ('\n') %}
+    {{ log(joined, info=True) }}
+    {% do return(joined) %}
+{% endif %}
 
 {{ return(results_list) }} 
 
@@ -33,10 +42,21 @@ order by 1
 
 {% endset %}
 
+{% set jinja_macro=[] %}
 {% set results = run_query(query) %}
 {% set results_list = results.columns[0].values() %}}
-{{ log(results_list, info=True)}} 
-{{ return(results_list) }}
+{% for col in results_list %}
+{% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
+{% endfor %}
+
+{% if execute %}
+    {% set joined = jinja_macro | join ('\n') %}
+    {{ log(joined, info=True) }}
+    {% do return(joined) %}
+{% endif %}
+
+{{ log(joined, info=True)}} 
+{{ return(joined) }}
 
 {% endmacro %}
 
@@ -45,3 +65,13 @@ order by 1
 {% macro get_column_names_only(table_name, schema_name, database_name) -%}
 {{ return(adapter.dispatch('get_column_names_only')(table_name, schema_name, database_name)) }}
 {%- endmacro %}
+
+
+-- % macro get_column_names_only_format(table_name, schema_name, database_name=target.database) -%}
+-- {% set columns = get_column_names_only(table_name, schema_name, database_name) %}
+
+-- {% for col in columns %}
+-- {% do jinja_macro.append('    ' ~ col ~ (',' if not loop.last)) %}
+-- {% endfor %}
+
+-- {% endmacro %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Further automating the staging model creation to prefill column fields in the final select statement.
**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
To test new macro `get_column_names_only`, use
`dbt run-operation get_column_names_only --args '{table_name: log, schema_name: fivetran_log, database_name: dbt-package-testing}' | tail -n +2 > fivetran_log/models/log__log_temp.sql`

Then to test how the actual bash script `generate_models` gets updated, use
`source dbt_packages/fivetran_utils/generate_models.sh '../dbt_fivetran_log_source' stg_fivetran_log dbt-package-testing fivetran_log log`


**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
Tested using fivetran log

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)

Updated the readme with adding the new macro + updated affected macros
