### PR TITLE
expand try_cast for snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_fivetran_utils v0.3.7
+## 🎉 Features 🎉 
+- Expands `try_cast()` capabilities for Snowflake. The native function can only convert fields that are originally strings. The macro now proactively casts the field as a string prior to casting it to the target datatype.
 # dbt_fivetran_utils v0.3.6
 ## 🎉 Features 🎉 
 - New macro `get_column_names_only` that further automates the staging model creation to prefill column fields in the final select statement. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# dbt_fivetran_utils v0.3.7
+# dbt_fivetran_utils v0.3.8
 ## 🎉 Features 🎉 
 - Expands `try_cast()` capabilities for Snowflake. The native function can only convert fields that are originally strings. The macro now proactively casts the field as a string prior to casting it to the target datatype.
+# dbt_fivetran_utils v0.3.7
+This is a roll back release to v0.3.5 to account for an issue introduced in v0.3.6
 # dbt_fivetran_utils v0.3.6
 ## 🎉 Features 🎉 
 - New macro `get_column_names_only` that further automates the staging model creation to prefill column fields in the final select statement. 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.3.6'
+version: '0.3.7'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.3.7'
+version: '0.3.8'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/try_cast.sql
+++ b/macros/try_cast.sql
@@ -40,7 +40,7 @@
 {% endmacro %}
 
 {% macro snowflake__try_cast(field, type) %}
-    try_cast({{field}} as {{type}})
+    try_cast(cast({{field}} as varchar) as {{type}})
 {% endmacro %}
 
 {% macro bigquery__try_cast(field, type) %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 

for snowflake, the native try_cast function can only convert string-type fields to another datatype (limited to the ones [here](https://docs.snowflake.com/en/sql-reference/functions/try_cast.html#usage-notes)). so if we try to convert a float to a numeric, such as in this issue https://github.com/fivetran/dbt_klaviyo/issues/21 snowflake throws an error.

my idea is to cast the field-arg as a string proactively. curious if there are concerns around losing precision with doing so though.....

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [ ] No (provide further explanation)
