### PR TITLE
bugfix/union-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# dbt_fivetran_utils v0.4.0-b1
+## Bug Fixes
+- The `union_data` macro has been adjusted to establish a source relation instead of a floating relation. 
+    - To leverage this macro in an environment where `dbt_fivetran_utils` is already installed, you can add the following to your `packages.yml` to install this version of the package:
+    ```yml
+    - git: https://github.com/fivetran/dbt_fivetran_utils.git
+        revision: bugfix/union-data
+        warn-unpinned: false
+    ```
+    - You can then add the following to your `dbt_project.yml` to dispatch this package version (`fivetran_utils_union`) in place of the original package (`dbt_fivetran_utils`).
+    ```yml
+    dispatch:
+        - macro_namespace: fivetran_utils
+            search_order: ['fivetran_utils_union','fivetran_utils']
+    ```
 # dbt_fivetran_utils v0.3.9
 ## 🎉 Features 🎉 
 - Addition of the `transform` argument to the `persist_pass_through_columns` macro. This argument is optional and will take in a SQL function (most likely an aggregate such as `sum`) you would like to apply to the passthrough columns ([81](https://github.com/fivetran/dbt_fivetran_utils/pull/81)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
         - macro_namespace: fivetran_utils
             search_order: ['fivetran_utils_union','fivetran_utils']
     ```
+
+    -- todo: update changelog after getting goahead on variable
 # dbt_fivetran_utils v0.3.9
 ## 🎉 Features 🎉 
 - Addition of the `transform` argument to the `persist_pass_through_columns` macro. This argument is optional and will take in a SQL function (most likely an aggregate such as `sum`) you would like to apply to the passthrough columns ([81](https://github.com/fivetran/dbt_fivetran_utils/pull/81)).

--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ If the `var` with the name of the `database_variable` argument is set, the macro
 
 When using this functionality, every `_tmp` table should use this macro as described below.
 
+To create dependencies between the unioned model and its **sources**, you must define the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package) to `True` in your `dbt_project.yml` file.
+
 **Usage:**
 ```sql
 {{

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'fivetran_utils_union'
-version: '0.3.9'
+name: 'fivetran_utils'
+version: '0.3.10'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'fivetran_utils'
+name: 'fivetran_utils_union'
 version: '0.3.9'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -1,6 +1,6 @@
 {% macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
-{{ adapter.dispatch('union_data', 'fivetran_utils_union') (
+{{ adapter.dispatch('union_data', 'fivetran_utils') (
     table_identifier, 
     database_variable, 
     schema_variable, 
@@ -36,11 +36,10 @@
     {% endif %}
 
     {% for schema in var(union_schema_variable) %}
-
     {% set relation=adapter.get_relation(
-        database=source(schema, table_identifier).database,
-        schema=source(schema, table_identifier).schema,
-        identifier=source(schema, table_identifier).identifier
+        database=source(schema, table_identifier).database if var('has_defined_sources', false) else var(database_variable, default_database),
+        schema=source(schema, table_identifier).schema if var('has_defined_sources', false) else schema,
+        identifier=source(schema, table_identifier).identifier if var('has_defined_sources', false) else table_identifier
     ) -%}
     
     {% set relation_exists=relation is not none %}
@@ -62,9 +61,9 @@
     {% for database in var(union_database_variable) %}
 
     {% set relation=adapter.get_relation(
-        database=source(schema, table_identifier).database,
-        schema=source(schema, table_identifier).schema,
-        identifier=source(schema, table_identifier).identifier
+        database=source(schema, table_identifier).database if var('has_defined_sources', false) else database,
+        schema=source(schema, table_identifier).schema if var('has_defined_sources', false) else var(schema_variable, default_schema),
+        identifier=source(schema, table_identifier).identifier if var('has_defined_sources', false) else table_identifier
     ) -%}
 
     {% set relation_exists=relation is not none %}

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -1,6 +1,6 @@
 {% macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
-{{ adapter.dispatch('union_data', 'fivetran_utils') (
+{{ adapter.dispatch('union_data', 'fivetran_utils_union') (
     table_identifier, 
     database_variable, 
     schema_variable, 
@@ -38,9 +38,9 @@
     {% for schema in var(union_schema_variable) %}
 
     {% set relation=adapter.get_relation(
-        database=var(database_variable, default_database),
-        schema=schema,
-        identifier=table_identifier
+        database=source(schema, table_identifier).database,
+        schema=source(schema, table_identifier).schema,
+        identifier=source(schema, table_identifier).identifier
     ) -%}
     
     {% set relation_exists=relation is not none %}
@@ -62,9 +62,9 @@
     {% for database in var(union_database_variable) %}
 
     {% set relation=adapter.get_relation(
-        database=database,
-        schema=var(schema_variable, default_schema),
-        identifier=table_identifier
+        database=source(schema, table_identifier).database,
+        schema=source(schema, table_identifier).schema,
+        identifier=source(schema, table_identifier).identifier
     ) -%}
 
     {% set relation_exists=relation is not none %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
## Bug Fixes
- The `union_data` macro has been adjusted to establish a source relation instead of a floating relation. 
    - To leverage this macro in an environment where `dbt_fivetran_utils` is already installed, you can add the following to your `packages.yml` to install this version of the package:
    ```yml
    - git: https://github.com/fivetran/dbt_fivetran_utils.git
      revision: bugfix/union-data
      warn-unpinned: false
    ```
    - You can then add the following to your `dbt_project.yml` to dispatch this package version (`fivetran_utils_union`) in place of the original package (`dbt_fivetran_utils`).
    ```yml
    dispatch:
      - macro_namespace: fivetran_utils
        search_order: ['fivetran_utils_union','fivetran_utils']
    ```
**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
This is not a new macro, instead it is changes to the existing `union_data` macro.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
This was tested on the Xero dataset and success was found! The key update needed here however is a source.yml for each source **must** be created. See below for the two source.yml I created in my development project (notice the only changes are the source name and schema name):
![image](https://user-images.githubusercontent.com/74217849/185475719-bca7b385-81db-4971-abec-2745c4add661.png)

In the end you can see the union working as intended!
![image](https://user-images.githubusercontent.com/74217849/185475927-58af1229-1bcc-4c43-b061-f155b0f44d7a.png)


**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)

No README changes required.
