### PR TITLE
Bugfix/dbt utils migrate string literal and type_string dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_fivetran_utils v0.4.1
+
+## Bug Fixes
+[PR #90](https://github.com/fivetran/dbt_fivetran_utils/pull/90) updates dispatch from `{{ dbt_utils.<macro> }}` to `{{ dbt.<macro> }}` for additional [cross-db macros](https://docs.google.com/spreadsheets/d/1xF_YwJ4adsnjFkUbUm8-EnEL1r_C-9_OI_pP4m4FlJU/edit#gid=1062533692) missed in the `fivetran_utils.union_relations()` macro.
+
 # dbt_fivetran_utils v0.4.0
 
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt_fivetran_utils v0.4.1
 
 ## Bug Fixes
-[PR #90](https://github.com/fivetran/dbt_fivetran_utils/pull/90) updates dispatch from `{{ dbt_utils.<macro> }}` to `{{ dbt.<macro> }}` for additional [cross-db macros](https://docs.google.com/spreadsheets/d/1xF_YwJ4adsnjFkUbUm8-EnEL1r_C-9_OI_pP4m4FlJU/edit#gid=1062533692) missed in the `fivetran_utils.union_relations()` macro.
+[PR #91](https://github.com/fivetran/dbt_fivetran_utils/pull/91) updates dispatch from `{{ dbt_utils.<macro> }}` to `{{ dbt.<macro> }}` for additional [cross-db macros](https://docs.google.com/spreadsheets/d/1xF_YwJ4adsnjFkUbUm8-EnEL1r_C-9_OI_pP4m4FlJU/edit#gid=1062533692) missed in the `fivetran_utils.union_relations()` macro.
 
 # dbt_fivetran_utils v0.4.0
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
 version: '0.4.1'
 config-version: 2
-require-dbt-version: [">=1.2.0", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.0'
+version: '0.4.1'
 config-version: 2
 require-dbt-version: [">=1.2.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.0'
+version: '0.4.1'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/union_relations.sql
+++ b/macros/union_relations.sql
@@ -62,7 +62,7 @@
         (
             select
 
-                cast({{ dbt_utils.string_literal(relation) }} as {{ dbt_utils.type_string() }}) as {{ source_column_name }},
+                cast({{ dbt.string_literal(relation) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
                 {% for col_name in ordered_column_names -%}
 
                     {%- set col = column_superset[col_name] %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
updates the dispatch for `string_literal` and `type_string` from dbt_utils to dbt for the `union_relations` macro. 

see https://docs.google.com/spreadsheets/d/1xF_YwJ4adsnjFkUbUm8-EnEL1r_C-9_OI_pP4m4FlJU/edit#gid=1062533692

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->

in marketo 

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

doesn't work with new dbt utils

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
