### PR TITLE
union data creates empty tables if none exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Feature Updates
 - ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning that the respective staging model is empty.
-  - The compiler warning can be turned off by the end user by setting the `remove_empty_table_warnings` variable to `True`.
+  - The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. This is achieved by:
-  - A new (optional, but recommended) `columm_macro` argument. This should be the `get_<table name>_columns()` macro stored in the `macros` folder of the source package, which returns all expected columns and their datatypes for source tables. 
-  - New output: If the `column_macro` argument is provided and the source table does not exist, `union_data` will create each of the missing table's fields as `null` and properly cast them. 
-  - New output: If the `column_macro` argument is not provided and the source table does not exist, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Feature Updates
 - ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning message that the respective staging model is empty.
-  - The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
+  - The compiler warning can be turned off by the end user by setting the globally-scoped `fivetran__remove_empty_table_warnings` variable to `True`.
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty (ie `limit 0`) with just one string column (`_dbt_source_relation`).
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`).
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning that the respective staging model is empty.
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning message that the respective staging model is empty.
   - The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
 
 # dbt_fivetran_utils v0.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`).
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning that the respective staging model is empty.
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_fivetran_utils v0.4.3
+
+## Feature Updates
+- Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the `get_<table name>_columns()` macro is provided as the `column_macro` argument and the source table does not exist, `union_data` will create each of the missing table's fields and properly cast them as `null`. If the macro is not provided and the source table still does not exist, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
+
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes
 - Fix broken anchor tags in README. ([PR #96](https://github.com/fivetran/dbt_fivetran_utils/pull/96))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Feature Updates
 - ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning message that the respective staging model is empty.
-  - The compiler warning can be turned off by the end user by setting the globally-scoped `fivetran__remove_empty_table_warnings` variable to `True`.
+  - The compiler warning can be turned off by the end user by setting the `fivetran__remove_empty_table_warnings` variable to `True`.
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the `get_<table name>_columns()` macro is provided as the `column_macro` argument and the source table does not exist, `union_data` will create each of the missing table's fields and properly cast them as `null`. If the macro is not provided and the source table still does not exist, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. This is achieved by:
+  - A new (optional, but recommended) `columm_macro` argument. This should be the `get_<table name>_columns()` macro stored in the `macros` folder of the source package, which returns all expected columns and their datatypes for source tables. 
+  - New output: If the `column_macro` argument is provided and the source table does not exist, `union_data` will create each of the missing table's fields as `null` and properly cast them. 
+  - New output: If the `column_macro` argument is not provided and the source table does not exist, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Feature Updates
 - ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`) and raise a compiler warning that the respective staging model is empty.
+  - The compiler warning can be turned off by the end user by setting the `remove_empty_table_warnings` variable to `True`.
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt_fivetran_utils v0.4.3
 
 ## Feature Updates
-- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will create a table with just one `null` field (`_dbt_source_relation`).
+- ([PR #100](https://github.com/fivetran/dbt_fivetran_utils/pull/100)) Expanded the `union_data` macro to create an empty table if none of the provided schemas or databases contain a source table. If the source table does not exist anywhere, `union_data` will return a **completely** empty (ie `limit 0`) with just one string column (`_dbt_source_relation`).
 
 # dbt_fivetran_utils v0.4.2
 ## Bug Fixes

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning will be raised, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning message will be output, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -44,42 +44,51 @@ dispatch:
 ----
 # 📋 Contents
 
-- [Tests and helpers](#tests-and-helpers)
-  - [collect_freshness](#collect_freshness-source)
-  - [seed_data_helper](#seed_data_helper-source)
-  - [snowflake_seed_data](#snowflake_seed_data-source)
-
-- [Cross-database compatibility](#cross-database-compatibility)
-  - [array_agg](#array_agg-source)
-  - [ceiling](#ceiling-source)
-  - [first_value](#first_value-source)
-  - [json_extract](#json_extract-source)
-  - [json_parse](#json_parse-source)
-  - [max_bool](#max_bool-source)
-  - [percentile](#percentile-source)
-  - [pivot_json_extract](#pivot_json_extract-source)
-  - [string_agg](#string_agg-source)
-  - [timestamp_add](#timestamp_add-source)
-  - [timestamp_diff](#timestamp_diff-source)
-  - [try_cast](#try_cast-source)
-
-- [SQL and field generators](#sql-and-field-generators)
-  - [add_dbt_source_relation](#add_dbt_source_relation-source)
-  - [add_pass_through_columns](#add_pass_through_columns-source)
-  - [calculated_fields](#calculated_fields-source)
-  - [dummy_coalesce_value](#dummy_coalesce_value-source)
-  - [fill_pass_through_columns](#fill_pass_through_columns-source)
-  - [fill_staging_columns](#fill_staging_columns-source)
-  - [persist_pass_through_columns](#persist_pass_through_columns-source)
-  - [remove_prefix_from_columns](#remove_prefix_from_columns-source)
-  - [source_relation](#source_relation-source)
-  - [union_data](#union_data-source)
-  - [union_relations](#union_relations-source)
-
-- [Variable Checks](#variable_checks)
-  - [empty_variable_warning](#empty_variable_warning-source)
-  - [enabled_vars](#enabled_vars-source)
-  - [enabled_vars_one_true](#enabled_vars_one_true-source)
+- [Fivetran Utility Macros for dbt](#fivetran-utility-macros-for-dbt)
+- [🤔 Who are the intended users of this package?](#-who-are-the-intended-users-of-this-package)
+- [📣 What does this dbt package do?](#-what-does-this-dbt-package-do)
+- [🎯 How do I use the dbt package?](#-how-do-i-use-the-dbt-package)
+  - [Step 1: Installing the Package](#step-1-installing-the-package)
+  - [Step 2: Using the Macros](#step-2-using-the-macros)
+- [📋 Contents](#-contents)
+  - [Tests and helpers](#tests-and-helpers)
+    - [collect\_freshness (source)](#collect_freshness-source)
+    - [seed\_data\_helper (source)](#seed_data_helper-source)
+    - [snowflake\_seed\_data (source)](#snowflake_seed_data-source)
+  - [Cross-database compatibility](#cross-database-compatibility)
+    - [array\_agg (source)](#array_agg-source)
+    - [ceiling (source)](#ceiling-source)
+    - [first\_value (source)](#first_value-source)
+    - [json\_extract (source)](#json_extract-source)
+    - [json\_parse (source)](#json_parse-source)
+    - [max\_bool (source)](#max_bool-source)
+    - [percentile (source)](#percentile-source)
+    - [pivot\_json\_extract (source)](#pivot_json_extract-source)
+    - [string\_agg (source)](#string_agg-source)
+    - [timestamp\_add (source)](#timestamp_add-source)
+    - [timestamp\_diff (source)](#timestamp_diff-source)
+    - [try\_cast (source)](#try_cast-source)
+  - [SQL and field generators](#sql-and-field-generators)
+    - [add\_dbt\_source\_relation (source)](#add_dbt_source_relation-source)
+    - [add\_pass\_through\_columns (source)](#add_pass_through_columns-source)
+    - [calculated\_fields (source)](#calculated_fields-source)
+    - [dummy\_coalesce\_value (source)](#dummy_coalesce_value-source)
+    - [fill\_pass\_through\_columns (source)](#fill_pass_through_columns-source)
+    - [fill\_staging\_columns (source)](#fill_staging_columns-source)
+    - [persist\_pass\_through\_columns (source)](#persist_pass_through_columns-source)
+    - [remove\_prefix\_from\_columns (source)](#remove_prefix_from_columns-source)
+    - [source\_relation (source)](#source_relation-source)
+    - [union\_data (source)](#union_data-source)
+    - [union\_relations (source)](#union_relations-source)
+  - [Variable Checks](#variable-checks)
+    - [empty\_variable\_warning (source)](#empty_variable_warning-source)
+    - [enabled\_vars (source)](#enabled_vars-source)
+    - [enabled\_vars\_one\_true (source)](#enabled_vars_one_true-source)
+- [🔍 Does this package have dependencies?](#-does-this-package-have-dependencies)
+- [🙌 How is this package maintained and can I contribute?](#-how-is-this-package-maintained-and-can-i-contribute)
+  - [Package Maintenance](#package-maintenance)
+  - [Contributions](#contributions)
+- [🏪 Are there any resources available?](#-are-there-any-resources-available)
 
 ----
 
@@ -445,6 +454,7 @@ To create dependencies between the unioned model and its *sources*, you **must d
         schema_variable='shopify_schema', 
         default_database=target.database,
         default_schema='shopify',
+        column_macro=get_customer_columns(),
         default_variable='customer_source'
     )
 }}
@@ -456,6 +466,7 @@ To create dependencies between the unioned model and its *sources*, you **must d
 * `default_database`: The default database where source data should be found. This is used when unioning schemas.
 * `default_schema`: The default schema where source data should be found. This is used when unioning databases.
 * `default_variable`: The name of the variable that users should populate when they want to pass one specific relation to this model (mostly used for CI)
+* `column_macro` (optional but recommended): The name of the macro leveraged by `fill_staging_columns()` which contains expected columns and their data types. Default value is `[{}]`.
 * `union_schema_variable` (optional): The name of the union schema variable. By default the macro will look for `union_schemas`.
 * `union_database_variable` (optional): The name of the union database variable. By default the macro will look for `union_databases`.
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning message will be output, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning message will be output, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the globally scoped `fivetran__remove_empty_table_warnings` variable to `True`.
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning message will be output, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the globally scoped `fivetran__remove_empty_table_warnings` variable to `True`.
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning message will be output, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the `fivetran__remove_empty_table_warnings` variable to `True`.
 
 **Usage:**
 ```sql
@@ -475,6 +475,8 @@ If the source table is not found in any of the provided schemas/databases, `unio
 vars:
   shopify_source:
     has_defined_sources: true
+  
+  fivetran__remove_empty_table_warnings: true # false by default
 ```
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`).
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning will be raised, highlighting that the expected source table was not found and its respective staging model is empty.
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty (ie `limit 0`) with just one string column (`_dbt_source_relation`).
+
 **Usage:**
 ```sql
 -- in model.sql file

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty (ie `limit 0`) with just one string column (`_dbt_source_relation`).
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`).
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -454,7 +454,6 @@ To create dependencies between the unioned model and its *sources*, you **must d
         schema_variable='shopify_schema', 
         default_database=target.database,
         default_schema='shopify',
-        column_macro=get_customer_columns(),
         default_variable='customer_source'
     )
 }}
@@ -466,7 +465,6 @@ To create dependencies between the unioned model and its *sources*, you **must d
 * `default_database`: The default database where source data should be found. This is used when unioning schemas.
 * `default_schema`: The default schema where source data should be found. This is used when unioning databases.
 * `default_variable`: The name of the variable that users should populate when they want to pass one specific relation to this model (mostly used for CI)
-* `column_macro` (optional but recommended): The name of the macro leveraged by `fill_staging_columns()` which contains expected columns and their data types. Default value is `[{}]`.
 * `union_schema_variable` (optional): The name of the union schema variable. By default the macro will look for `union_schemas`.
 * `union_database_variable` (optional): The name of the union database variable. By default the macro will look for `union_databases`.
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ When using this functionality, every `_tmp` table should use this macro as descr
 
 To create dependencies between the unioned model and its *sources*, you **must define** the source tables in a `.yml` file in your project and set the `has_defined_sources` variable (scoped to the source package in which the macro is being called) to `True` in your `dbt_project.yml` file. If you set `has_defined_sources` to true and do not define sources (at least adding the `name` of each table in the source), dbt will throw an error.
 
-If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning will be raised, highlighting that the expected source table was not found and its respective staging model is empty.
+If the source table is not found in any of the provided schemas/databases, `union_data` will return a **completely** empty table (ie `limit 0`) with just one string column (`_dbt_source_relation`). A compiler warning will be raised, highlighting that the expected source table was not found and its respective staging model is empty. The compiler warning can be turned off by the end user by setting the global `remove_empty_table_warnings` variable to `True`.
 
 **Usage:**
 ```sql

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.1'
+version: '0.4.3'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.1'
+version: '0.4.3'
 config-version: 2
 profile: 'integration_tests'

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -55,6 +55,7 @@
     {%- else -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
+    limit 0
     {%- endif -%}
 
 {%- elif var(union_database_variable, none) -%}
@@ -81,6 +82,7 @@
     {%- else -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
+    limit 0
     {%- endif -%}
 
 {%- else -%}
@@ -97,6 +99,7 @@
 {%- else -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
+    limit 0
 {%- endif -%}
 {%- endif -%}
 

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -53,6 +53,7 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0
@@ -80,6 +81,7 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0
@@ -97,6 +99,7 @@
     select * 
     from {{ var(default_variable) }}
 {%- else -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -1,4 +1,4 @@
-{% macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
+{%- macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, column_macro=[{}], union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
 {{ adapter.dispatch('union_data', 'fivetran_utils') (
     table_identifier, 
@@ -7,82 +7,102 @@
     default_database, 
     default_schema, 
     default_variable,
+    column_macro,
     union_schema_variable,
     union_database_variable
     ) }}
 
-{%- endmacro %}
+{%- endmacro -%}
 
-{% macro default__union_data(
+{%- macro default__union_data(
     table_identifier, 
     database_variable, 
     schema_variable, 
     default_database, 
     default_schema, 
     default_variable,
+    column_macro,
     union_schema_variable,
     union_database_variable
-    ) %}
+    ) -%}
 
-{% if var(union_schema_variable, none) %}
+{%- if var(union_schema_variable, none) -%}
 
-    {% set relations = [] %}
+    {%- set relations = [] -%}
     
-    {% if var(union_schema_variable) is string %}
-    {% set trimmed = var(union_schema_variable)|trim('[')|trim(']') %}
-    {% set schemas = trimmed.split(',')|map('trim'," ")|map('trim','"')|map('trim',"'") %}
-    {% else %}
-    {% set schemas = var(union_schema_variable) %}
-    {% endif %}
+    {%- if var(union_schema_variable) is string -%}
+    {%- set trimmed = var(union_schema_variable)|trim('[')|trim(']') -%}
+    {%- set schemas = trimmed.split(',')|map('trim'," ")|map('trim','"')|map('trim',"'") -%}
+    {%- else -%}
+    {%- set schemas = var(union_schema_variable) -%}
+    {%- endif -%}
 
-    {% for schema in var(union_schema_variable) %}
-    {% set relation=adapter.get_relation(
+    {%- for schema in var(union_schema_variable) -%}
+    {%- set relation=adapter.get_relation(
         database=source(schema, table_identifier).database if var('has_defined_sources', false) else var(database_variable, default_database),
         schema=source(schema, table_identifier).schema if var('has_defined_sources', false) else schema,
         identifier=source(schema, table_identifier).identifier if var('has_defined_sources', false) else table_identifier
     ) -%}
     
-    {% set relation_exists=relation is not none %}
+    {%- set relation_exists=relation is not none -%}
 
-    {% if relation_exists %}
+    {%- if relation_exists -%}
+        {%- do relations.append(relation) -%}
+    {%- endif -%}
 
-    {% do relations.append(relation) %}
+    {%- endfor -%}
     
-    {% endif %}
+    {%- if relations != [] -%}
+        {{ dbt_utils.union_relations(relations) }}
+    {%- else -%}
+    select 
+        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
+        {%- if column_macro is not none%},{%- endif -%} null as _dbt_source_relation
+    {%- endif -%}
 
-    {% endfor %}
+{%- elif var(union_database_variable, none) -%}
 
-    {{ dbt_utils.union_relations(relations) }}
+    {%- set relations = [] -%}
 
-{% elif var(union_database_variable, none) %}
-
-    {% set relations = [] %}
-
-    {% for database in var(union_database_variable) %}
-
-    {% set relation=adapter.get_relation(
+    {%- for database in var(union_database_variable) -%}
+    {%- set relation=adapter.get_relation(
         database=source(schema, table_identifier).database if var('has_defined_sources', false) else database,
         schema=source(schema, table_identifier).schema if var('has_defined_sources', false) else var(schema_variable, default_schema),
         identifier=source(schema, table_identifier).identifier if var('has_defined_sources', false) else table_identifier
     ) -%}
 
-    {% set relation_exists=relation is not none %}
+    {%- set relation_exists=relation is not none -%}
 
-    {% if relation_exists %}
+    {%- if relation_exists -%}
+        {%- do relations.append(relation) -%}
+    {%- endif -%}
 
-    {% do relations.append(relation) %}
-    
-    {% endif %}
+    {%- endfor -%}
 
-    {% endfor %}
+    {%- if relations != [] -%}
+        {{ dbt_utils.union_relations(relations) }}
+    {%- else -%}
+    select 
+        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
+        {%- if column_macro != [{}] %},{%- endif -%} null as _dbt_source_relation
+    {%- endif -%}
 
-    {{ dbt_utils.union_relations(relations) }}
+{%- else -%}
+    {%- set relation=adapter.get_relation(
+        database=var(database_variable, default_database),
+        schema=var(schema_variable, default_schema),
+        identifier=var(default_schema ~ '_' ~ table_identifier ~ '_' ~ 'identifier', table_identifier)) -%}
 
-{% else %}
+{%- set table_exists=relation is not none -%}
 
+{%- if table_exists -%}
     select * 
     from {{ var(default_variable) }}
+{%- else -%}
+    select 
+        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
+        {%- if column_macro != [{}] %},{%- endif -%} null as _dbt_source_relation
+{%- endif -%}
+{%- endif -%}
 
-{% endif %}
-
-{% endmacro %}
+{%- endmacro -%}

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -56,8 +56,8 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     select 
-        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
-        {%- if column_macro is not none%},{%- endif -%} null as _dbt_source_relation
+        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%} 
+        cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     {%- endif -%}
 
 {%- elif var(union_database_variable, none) -%}
@@ -83,8 +83,8 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     select 
-        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
-        {%- if column_macro != [{}] %},{%- endif -%} null as _dbt_source_relation
+        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%}
+        cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     {%- endif -%}
 
 {%- else -%}
@@ -100,8 +100,8 @@
     from {{ var(default_variable) }}
 {%- else -%}
     select 
-        {{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }}
-        {%- if column_macro != [{}] %},{%- endif -%} null as _dbt_source_relation
+        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%}
+        cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
 {%- endif -%}
 {%- endif -%}
 

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -53,7 +53,9 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0
@@ -81,7 +83,9 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0
@@ -99,7 +103,9 @@
     select * 
     from {{ var(default_variable) }}
 {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}{{ exceptions.warn("\n\nWarning: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations.\n") }}{% endif -%}
+    {% if execute and not var('remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     limit 0

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -1,4 +1,4 @@
-{%- macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, column_macro=[{}], union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
+{%- macro union_data(table_identifier, database_variable, schema_variable, default_database, default_schema, default_variable, union_schema_variable='union_schemas', union_database_variable='union_databases') -%}
 
 {{ adapter.dispatch('union_data', 'fivetran_utils') (
     table_identifier, 
@@ -7,7 +7,6 @@
     default_database, 
     default_schema, 
     default_variable,
-    column_macro,
     union_schema_variable,
     union_database_variable
     ) }}
@@ -21,7 +20,6 @@
     default_database, 
     default_schema, 
     default_variable,
-    column_macro,
     union_schema_variable,
     union_database_variable
     ) -%}
@@ -56,7 +54,6 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     select 
-        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%} 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     {%- endif -%}
 
@@ -83,7 +80,6 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     select 
-        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%}
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
     {%- endif -%}
 
@@ -100,7 +96,6 @@
     from {{ var(default_variable) }}
 {%- else -%}
     select 
-        {% if column_macro != [{}] %}{{ fivetran_utils.fill_staging_columns(source_columns=[], staging_columns=column_macro) }},{% endif -%}
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
 {%- endif -%}
 {%- endif -%}

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -54,7 +54,7 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier|upper ~ " table was not found in your " ~ default_schema|upper ~ " schema(s). The Fivetran dbt package will create a completely empty " ~ table_identifier|upper ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to TRUE (see https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#union_data-source for details).\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -84,7 +84,7 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier|upper ~ " table was not found in your " ~ default_schema|upper ~ " schema(s). The Fivetran dbt package will create a completely empty " ~ table_identifier|upper ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to TRUE (see https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#union_data-source for details).\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -104,7 +104,7 @@
     from {{ var(default_variable) }}
 {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier|upper ~ " table was not found in your " ~ default_schema|upper ~ " schema(s). The Fivetran dbt package will create a completely empty " ~ table_identifier|upper ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to TRUE (see https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#union_data-source for details).\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -54,7 +54,7 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -84,7 +84,7 @@
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -104,7 +104,7 @@
     from {{ var(default_variable) }}
 {%- else -%}
     {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to True.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -53,8 +53,8 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -83,8 +83,8 @@
     {%- if relations != [] -%}
         {{ dbt_utils.union_relations(relations) }}
     {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation
@@ -103,8 +103,8 @@
     select * 
     from {{ var(default_variable) }}
 {%- else -%}
-    {% if execute and not var('remove_empty_table_warnings', false) -%}
-    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your destination. The package will create a completely empty staging model as to not break downstream transformations. To turn off these warnings, set the `remove_empty_table_warnings` variable to False.\n") }}
+    {% if execute and not var('fivetran__remove_empty_table_warnings', false) -%}
+    {{ exceptions.warn("\n\nPlease be aware: The " ~ table_identifier ~ " table was not found in your " ~ default_schema ~ " schema(s). The package will create a completely empty " ~ table_identifier ~ " staging model as to not break downstream transformations. To turn off these warnings, set the `fivetran__remove_empty_table_warnings` variable to False.\n") }}
     {% endif -%}
     select 
         cast(null as {{ dbt.type_string() }}) as _dbt_source_relation


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
- adds argument to union_data to handle when there's no table in any of the provided schemas/databases (by creating an empty table) 

https://github.com/fivetran/dbt_fivetran_utils/issues/99 (came out of https://github.com/fivetran/dbt_shopify_source/issues/57)

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
on shopify

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

Packages that use the `union_data` macro (found by searching `union_data` on github within the Fivetran org), and the impact of this change on them:
- Facebook pages
  - If a table doesn’t exist, in previous versions the package would have failed. Now it creates an empty ones and works with those
- Twitter organic  
  - If a table doesn’t exist, in previous versions the package would have failed. Now it creates an empty ones and works with those
- Instagram business
  - If a table doesn’t exist, in previous versions the package would have failed. Now it creates an empty ones and works with those
- Linkedin pages 
  - If a table doesn’t exist, in previous versions the package would have failed. Now it creates an empty ones and works with those
- Stripe
  - Instead of dynamically creating empty tables, Stripe currently has using__tablename variables to disable these. So for customers that have these set to false, nothing changes.
  - For customers that have these set to true, and the table exists, nothing changes. 
  - For customers that have these set to true, and the table doesn’t exist, we are resolving an error.
  - For tables that aren’t covered by the variables, if they don’t exist, they caused errors in previous versions. Now they won’t
- Xero
  - Instead of dynamically creating empty tables, xero currently has using__tablename variables to disable these (2). So for customers that have these set to false, nothing changes.
  - For customers that have these set to true, and the table exists, nothing changes. 
  - For customers that have these set to true, and the table doesn’t exist, we are resolving an error.
  - For tables that aren’t covered by the variables, if they don’t exist, they caused errors in previous versions. Now they won’t
- Klaviyo 
  - If a table doesn’t exist, in previous versions the package would have failed. Now it creates an empty ones and works with those

Packages upstream of the above:
- Shopify holistic reporting
- social media reporting

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
