### PR TITLE
bugfix/union-data-coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_fivetran_utils v0.4.7
+## Feature Updates
+- Update to the `union_data` macro to ensure a source connection is established when just one schema is being used with the macro. 
+    - The previous build did allow the macro to read data from the correct location; however, it did not leverage the source. Therefore, the models using this macro would result in not having a source connection. This has since been updated in this release and all versions of this macro (whether unioning or not) will attempt to leverage the source function.
+- In addition to the above update, a specific code adjustment was provided for the LinkedIn Company Pages and Instagram Business Pages packages as the sources are not named the same as their default schema. This was the core issue that resulted in dbt_fivetran_utils v0.4.5 being rolled back. This has now been addressed and may be expanded in the future for any other packages with mismatching source/default_schema names.
+    - For additional context, this is the approach taken as renaming the sources could result in incompatible versions of base package and fivetran_utils. Particularly, this could result in package users having a different experience based on the version of their base package. Which is not the behavior we would prefer for this new feature.
 # dbt_fivetran_utils v0.4.6
 ## Bug Fixes
 - Rolling back an error within the v0.4.5 release that caused a breaking change for the LinkedIn Pages dbt Package

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.6'
+version: '0.4.7'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.6'
+version: '0.4.7'
 config-version: 2
 profile: 'integration_tests'
 

--- a/macros/union_data.sql
+++ b/macros/union_data.sql
@@ -92,10 +92,26 @@
     {%- endif -%}
 
 {%- else -%}
-    {%- set relation=adapter.get_relation(
-        database=var(database_variable, default_database),
-        schema=var(schema_variable, default_schema),
-        identifier=var(default_schema ~ '_' ~ table_identifier ~ '_' ~ 'identifier', table_identifier)) -%}
+    {% set exception_schemas = {"linkedin_company_pages": "linkedin_pages", "instagram_business_pages": "instagram_business"} %}
+
+    {% if default_schema in exception_schemas.keys() %}
+        {% for corrected_schema_name in exception_schemas.items() %}   
+            {% if default_schema in corrected_schema_name %}
+                {%- set relation=adapter.get_relation(
+                    database=source(corrected_schema_name[1], table_identifier).database,
+                    schema=source(corrected_schema_name[1], table_identifier).schema,
+                    identifier=source(corrected_schema_name[1], table_identifier).identifier
+                ) -%}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+
+        {%- set relation=adapter.get_relation(
+            database=source(default_schema, table_identifier).database,
+            schema=source(default_schema, table_identifier).schema,
+            identifier=source(default_schema, table_identifier).identifier
+        ) -%}
+    {% endif %}
 
 {%- set table_exists=relation is not none -%}
 


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
This PR adjusts the `union_data` macro to ensure a source connection may be established regardless of unioning schemas or not. This is a mirror PR to PR #110 with the addition of handling the error which resulted from `v0.4.5` where the `default_schema` name did not always map to the name of the source.yml in the package. This caused compilation errors for customers and **MUST** be avoided and addressed.

Unfortunately, the only way to address this is to hard code the exceptions and performing a proper mapping exercise. As this behavior is only present in two packages, it is not too much of a risk, but this can be expanded in the future to include more as we roll out this feature. 

A few other approaches I took include the following:
- Adding a new argument to the macro that allows the package to provide the actual source name (regardless if it matches the default schema name). However, this did not prove to be viable as this would only be available in the latest versions of the impacted packages. Therefore, customers who have pinned versions of the packages would experience failures which is not ideal.
- Using a different argument from the original macro to obtain the source name. This was inconclusive and default_schema name was consistently the best option
  - This did make me think that we should **always** make the source name the default schema name in our packages. At least for consistency.
- Performing a trip or some manipulation procedure on the default_schema name. This proved to be more "hacky" than the exception mapping approach I took.

Very much open to other ideas if any have them.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
This is not a new macro but rather an expansion of the existing `union_data` macro.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
This update mainly impacts packages using the union_data macro. As such, this version of fivetran_utils was tested on **all** of the following packages:
- dbt_shopify_source
- dbt_klaviyo_source
- dbt_stripe_source
- dbt_xero_source
- dbt_quickbooks_source
- dbt_linkedin_pages_source
- dbt_instagram_business_source
- dbt_twitter_organic_source
- dbt_facebook_pages_source

Additional packages this was tested on include:
- dbt_fivetran_log
- dbt_zendesk
- dbt_shopify_holistic_reporting

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [X] No (provide further explanation)
The README updates were already applied in the previous PR linked above.
