### PR TITLE
feature/collect-freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_fivetran_utils v0.4.8
+[PR #127](https://github.com/fivetran/dbt_fivetran_utils/pull/127) includes the following updates.
+## Feature Updates
+- Updated the `collect_freshness` macro for compatibility with dbt versions greater than v1.5.0 to prevent erroneous warnings from occurring during freshness tests.
+
 # dbt_fivetran_utils v0.4.7
 [PR #118](https://github.com/fivetran/dbt_fivetran_utils/pull/118) includes the following updates.
 ## Feature Updates

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.7'
+version: '0.4.8'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.7'
+version: '0.4.8'
 config-version: 2
 profile: 'integration_tests'
 

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -76,5 +76,9 @@ packages:
     version: [">=0.1.0", "<1.0.0"]
   - package: fivetran/zendesk
     version: [">=0.1.0", "<1.0.0"]
-  - package: fivetran/intercom
-    version: [">=0.1.0", "<1.0.0"]
+  # - package: fivetran/intercom
+  #   version: [">=0.1.0", "<1.0.0"]
+    # put this back when package versions updated in intercom_source
+  - git: https://github.com/fivetran/dbt_intercom.git
+    revision: test/calogica_version_update
+    warn-unpinned: false

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -2,15 +2,15 @@ packages:
   - package: fivetran/ad_reporting
     version: [">=1.0.0", "<2.0.0"]
 
-  - package: fivetran/shopify_holistic_reporting
-    version: [">=0.1.0", "<1.0.0"]
-
-  ## To be switched after the social media integration tests is updated
-  # - package: fivetran/social_media_reporting
+  # - package: fivetran/shopify_holistic_reporting
   #   version: [">=0.1.0", "<1.0.0"]
-  - git: https://github.com/fivetran/dbt_social_media_reporting.git
-    revision: MagicBot/integation-test-webhooks-14
-    warn-unpinned: false 
+  # put this back when package versions updated in shopify_holistic_reporting
+  - git: https://github.com/fivetran/dbt_shopify_holistic_reporting.git
+    revision: test/update-shopify-versions
+    warn-unpinned: false
+
+  - package: fivetran/social_media_reporting
+    version: [">=0.1.0", "<1.0.0"]
 
   - package: fivetran/youtube_analytics
     version: [">=0.1.0", "<1.0.0"]

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -5,3 +5,5 @@ dbt-postgres>=1.3.0,<2.0.0
 dbt-spark>=1.3.0,<2.0.0
 dbt-spark[PyHive]>=1.3.0,<2.0.0
 dbt-databricks>=1.3.0,<2.0.0
+
+oscrypto @ git+https://github.com/wbond/oscrypto.git@d5f3437

--- a/macros/collect_freshness.sql
+++ b/macros/collect_freshness.sql
@@ -31,5 +31,11 @@
     {% endif %}
 
   {% endcall %}
-  {{ return(load_result('collect_freshness').table) }}
+
+  {% if dbt_version.split('.') | map('int') | list >= [1, 5, 0]  %}
+    {{ return(load_result('collect_freshness')) }}
+  {% else %}
+    {{ return(load_result('collect_freshness').table) }}
+  {% endif %}
+
 {% endmacro %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Issue #126 
Updates the collect freshness macro to use the correct syntax of `load_result`, depending on what version of dbt is being used. This prevents warnings being generated when using old syntax in dbt versions greater than 1.5.0.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
- N/A

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

- https://github.com/fivetran/dbt_google_play_source
  - tested on dbt_google_play_source using dbt 1.4 and 1.6. No errors generated in either case.
  - Used print statements to verify logic was activating correctly for versions like "1.10.0". 
- https://github.com/fivetran/dbt_twilio_source
- https://github.com/fivetran/dbt_apple_store_source
- https://github.com/fivetran/dbt_iterable_source
- https://github.com/fivetran/dbt_greenhouse_source
- https://github.com/fivetran/dbt_github_source
- https://github.com/fivetran/dbt_intercom_source
- https://github.com/fivetran/dbt_zendesk_source

- Will run the buildkite job to test all packages once approved.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [ ] Yes
- [x] No (provide further explanation) 
  - This does not change the readme instructions. 
