### PR TITLE
add and incorporate macro for turning jsons (and only jsons) into strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ dispatch:
   - [Cross-database compatibility](#cross-database-compatibility)
     - [array\_agg (source)](#array_agg-source)
     - [ceiling (source)](#ceiling-source)
+    - [get\_json\_columns\_in\_relation (source)](#get_json_columns_in_relation-source)
     - [first\_value (source)](#first_value-source)
     - [json\_extract (source)](#json_extract-source)
     - [json\_parse (source)](#json_parse-source)
@@ -81,6 +82,7 @@ dispatch:
     - [remove\_prefix\_from\_columns (source)](#remove_prefix_from_columns-source)
     - [source\_relation (source)](#source_relation-source)
     - [union\_data (source)](#union_data-source)
+      - [Union Data Defined Sources Configuration](#union-data-defined-sources-configuration)
     - [union\_relations (source)](#union_relations-source)
   - [Variable Checks](#variable-checks)
     - [empty\_variable\_warning (source)](#empty_variable_warning-source)
@@ -170,6 +172,19 @@ than, or equal to, the specified numeric expression. The ceiling macro is compat
 ```
 **Args:**
 * `num` (required): The integer field you wish to apply the ceiling function.
+
+----
+### get_json_columns_in_relation ([source](macros/get_json_columns_in_relation.sql))
+In BigQuery warehouses, this macro returns the names of columns that are of type JSON (as opposed to a string), given a model or source's columns. For non-BigQuery destinations, it will always return an empty list, as JSON support has not yet been rolled out to other Fivetran destinations.
+
+**Usage:**
+```sql
+{{ fivetran_utils.get_json_columns_in_relation(source_columns=adapter.get_columns_in_relation(ref('stg_fivetran_platform__connector_tmp'))) }}
+```
+**Args:**
+* `source_columns` (required): The columns of the relation. This will likely be a call to `adapter.get_columns_in_relation`.
+
+> In Fivetran modeling packages, the `get_json_columns_in_relation` macro is called within the [fivetran_utils.fill_staging_columns](macros/fill_staging_columns.sql) macro.
 
 ----
 ### first_value ([source](macros/first_value.sql))
@@ -429,6 +444,8 @@ from source
 **Args:**
 * `source_columns`  (required): Will call the [get_columns_in_relation](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter/#get_columns_in_relation) macro as well requires a `ref()` or `source()` argument for the staging models within the `_tmp` directory.
 * `staging_columns` (required): Created as a result of running the [generate_columns_macro](https://github.com/fivetran/dbt_fivetran_utils#generate_columns_macro-source) for the respective table.
+
+> This macro makes a call to `fivetran_utils.get_json_columns_in_relation()`, which returns source columns that are JSONs (BigQuery only). It will wrap each JSON field in [TO_JSON_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#to_json_string) and convert each to a string.
 
 ----
 ### persist_pass_through_columns ([source](macros/persist_pass_through_columns.sql))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.8'
+version: '0.4.9'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.8'
+version: '0.4.9'
 config-version: 2
 profile: 'integration_tests'
 

--- a/macros/fill_staging_columns.sql
+++ b/macros/fill_staging_columns.sql
@@ -2,10 +2,20 @@
 
 {%- set source_column_names = source_columns|map(attribute='name')|map('lower')|list -%}
 
+{%- set json_columns = [] -%}
+{% if target.type == 'bigquery' %}
+    {%- set json_columns = fivetran_utils.get_json_columns_in_relation(source_columns) -%}
+    {{ log(json_columns|lower, info=true)}}
+{% endif %}
+
 {%- for column in staging_columns %}
     {% if column.name|lower in source_column_names -%}
-        {{ fivetran_utils.quote_column(column) }} as 
-        {%- if 'alias' in column %} {{ column.alias }} {% else %} {{ fivetran_utils.quote_column(column) }} {%- endif -%}
+        {%- if column.name|lower in json_columns|lower -%}
+            TO_JSON_STRING( {{ fivetran_utils.quote_column(column) }} )
+        {%- else -%}
+            {{ fivetran_utils.quote_column(column) }} 
+        {%- endif %}
+        as {%- if 'alias' in column %} {{ column.alias }} {% else %} {{ fivetran_utils.quote_column(column) }} {%- endif -%}
     {%- else -%}
         cast(null as {{ column.datatype }})
         {%- if 'alias' in column %} as {{ column.alias }} {% else %} as {{ fivetran_utils.quote_column(column) }} {% endif -%}

--- a/macros/fill_staging_columns.sql
+++ b/macros/fill_staging_columns.sql
@@ -5,7 +5,6 @@
 {%- set json_columns = [] -%}
 {% if target.type == 'bigquery' %}
     {%- set json_columns = fivetran_utils.get_json_columns_in_relation(source_columns) -%}
-    {{ log(json_columns|lower, info=true)}}
 {% endif %}
 
 {%- for column in staging_columns %}

--- a/macros/get_json_columns_in_relation.sql
+++ b/macros/get_json_columns_in_relation.sql
@@ -6,7 +6,9 @@
 
 -- currently only need this for bigquery, so for everything else do nothing and just return an empty list
 {% macro default__get_json_columns_in_relation(source_columns) %}
+
 {{ return([]) }}
+
 {% endmacro %}
 
 -- we will return the columns that are of JSON type

--- a/macros/get_json_columns_in_relation.sql
+++ b/macros/get_json_columns_in_relation.sql
@@ -1,0 +1,29 @@
+{% macro get_json_columns_in_relation(source_columns) %}
+
+{{ adapter.dispatch('get_json_columns_in_relation', 'fivetran_utils') (source_columns) }}
+
+{%- endmacro %}
+
+-- currently only need this for bigquery, so for everything else do nothing and just return an empty list
+{% macro default__get_json_columns_in_relation(source_columns) %}
+{{ return([]) }}
+{% endmacro %}
+
+-- we will return the columns that are of JSON type
+{% macro bigquery__get_json_columns_in_relation(source_columns) %}
+
+{% set json_columns = [] %}
+
+{% set sc = source_columns|list %}
+
+{% for col_index in range(sc|length) %}
+
+    {% if sc[col_index].dtype|lower == 'json' %}
+        {% do json_columns.append(sc[col_index].name) %}
+        
+    {% endif %}
+{% endfor %}
+
+{{ return(json_columns) }}
+
+{% endmacro %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 

- Adds new macro, `get_json_columns_in_relation` to return a list of columns that are of type JSON (on BigQuery only, as we haven't rolled out JSON support in other Fivetran destinations). 
- Includes call to `get_json_columns_in_relation` in `fill_staging_columns`, so that each JSON field gets converted to a json-formatted STRING. This is necessary because only some connectors have JSONs currently and downstream json functions do not work seamlessly with the actual JSON-type columns.
  - `fill_staging_columns` was chosen as this is called in every (most?) source package model. therefore, we don't have to mass update a bunch of packages. however, we want this to be right and not break anything! 

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
## get_json_columns_in_relation
I first tested `get_json_columns_in_relation` by directly calling it in a local test model.

the model i ran it _against_ was just a select * from Joe's seed file 
`tiktok_ads_source_integration_tests_2.tiktok_adgroup_history_data`, which contains a JSON field called `AGE_GROUPS`. 

<img width="802" alt="image" src="https://github.com/fivetran/dbt_fivetran_utils/assets/65564846/5c36dc09-914f-43d3-9cf9-827df565f0b5">

When running, the test model, i was able to get the macro to return and output `['AGE_GROUPS']`

## fill_staging_columns
I tested the incorporation of `get_json_columns_in_relation` into `fill_staging_columns` by running the tiktok ads source package (specifically from the `integration_tests` folder) locally. 

With `tiktok_adgroup_history_data` as the source, the model where trouble would pop up was `stg_tiktok_ads__ad_group_history`, specifically on the line where we try to coalesce `age_groups` and an actual-string field, `age`.  
<img width="664" alt="image" src="https://github.com/fivetran/dbt_fivetran_utils/assets/65564846/eeb0a9e3-4241-4128-8519-2ecaa7409969">

With my additions, the fields CTE in `stg_tiktok_ads__ad_group_history` compiles to the following 
```sql
fields as (

    select
       
    
    action_days
   
        as 
    
    action_days
    
, 
    
    adgroup_id
    
        as 
    
    adgroup_id

# ................ cutting stuff out that's not relevant .......................... #

, 
    cast(null as string) as 
    
    age
    
 , 
    TO_JSON_STRING( 
    
    age_groups
    
 )
        as 
    
    age_groups
    
, 
    
    languages
   
        as 
    
    languages
    

, cast('' as string) as source_relation

    from base
), 
```

And so the coalesce of `age_groups` and `age` in the final CTE does not cause an error and the model runs successfully. 

and the data looks OK in bigquery
<img width="495" alt="image" src="https://github.com/fivetran/dbt_fivetran_utils/assets/65564846/a6c56103-292b-48f6-bfc7-f736cec11d46">


**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

Honestly we should test this with other packages as well -- ones with JSONs and not -- given the far-reaching nature of this macro change. perhaps we could have some customers try this out

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
