### PR TITLE
support for SQL server compatibility in the fivetran_log package

### DIFF
--- a/.buildkite/scripts/run_standard_models.sh
+++ b/.buildkite/scripts/run_standard_models.sh
@@ -24,7 +24,8 @@ do
     echo -e "\ncompiling "$package"\n"
     cd dbt_packages/$package/integration_tests/
     dbt deps
-    cp ../../../packages_ft_utils_override.yml packages.yml
+    ## Post dbt 1.7.0 we need to edit the package-lock.yml instead of the packages.yml
+    awk '/- package: fivetran\/fivetran_utils/ {print "- local: ../../../../"; skip=1; next} skip && /^  version:/ {skip=0; next} 1' package-lock.yml > temp.yml && mv temp.yml package-lock.yml
     dbt deps
     if [ "$package" = "linkedin" ]; then
         value_to_replace=$(grep ""$package"_ads_schema:" dbt_project.yml | awk '{ print $2 }')

--- a/.buildkite/scripts/run_standard_models.sh
+++ b/.buildkite/scripts/run_standard_models.sh
@@ -17,6 +17,7 @@ echo `pwd`
 cd integration_tests
 dbt deps ## Install all packages needed
 rm package-lock.yml
+echo -e "removing package-lock.yml"
 
 shift ## Skips the first argument (warehouse) and moves to only looking at the package arguments
 
@@ -24,11 +25,14 @@ for package in "$@" ## Iterates over all non warehouse arguments
 do
     echo -e "\ncompiling "$package"\n"
     cd dbt_packages/$package/integration_tests/
+    dbt clean
     dbt deps
     rm package-lock.yml
+    echo -e "removing package-lock.yml"
     cp ../../../packages_ft_utils_override.yml packages.yml
     dbt deps
     rm package-lock.yml
+    echo -e "removing package-lock.yml"
     if [ "$package" = "linkedin" ]; then
         value_to_replace=$(grep ""$package"_ads_schema:" dbt_project.yml | awk '{ print $2 }')
         perl -i -pe "s/(schema: |dataset: ).*/\1$value_to_replace/" ~/.dbt/profiles.yml

--- a/.buildkite/scripts/run_standard_models.sh
+++ b/.buildkite/scripts/run_standard_models.sh
@@ -16,6 +16,7 @@ db=$1
 echo `pwd`
 cd integration_tests
 dbt deps ## Install all packages needed
+rm package-lock.yml
 
 shift ## Skips the first argument (warehouse) and moves to only looking at the package arguments
 
@@ -24,8 +25,10 @@ do
     echo -e "\ncompiling "$package"\n"
     cd dbt_packages/$package/integration_tests/
     dbt deps
+    rm package-lock.yml
     cp ../../../packages_ft_utils_override.yml packages.yml
     dbt deps
+    rm package-lock.yml
     if [ "$package" = "linkedin" ]; then
         value_to_replace=$(grep ""$package"_ads_schema:" dbt_project.yml | awk '{ print $2 }')
         perl -i -pe "s/(schema: |dataset: ).*/\1$value_to_replace/" ~/.dbt/profiles.yml

--- a/.buildkite/scripts/run_standard_models.sh
+++ b/.buildkite/scripts/run_standard_models.sh
@@ -16,8 +16,6 @@ db=$1
 echo `pwd`
 cd integration_tests
 dbt deps ## Install all packages needed
-rm package-lock.yml
-echo -e "removing package-lock.yml"
 
 shift ## Skips the first argument (warehouse) and moves to only looking at the package arguments
 
@@ -25,14 +23,9 @@ for package in "$@" ## Iterates over all non warehouse arguments
 do
     echo -e "\ncompiling "$package"\n"
     cd dbt_packages/$package/integration_tests/
-    dbt clean
     dbt deps
-    rm package-lock.yml
-    echo -e "removing package-lock.yml"
     cp ../../../packages_ft_utils_override.yml packages.yml
     dbt deps
-    rm package-lock.yml
-    echo -e "removing package-lock.yml"
     if [ "$package" = "linkedin" ]; then
         value_to_replace=$(grep ""$package"_ads_schema:" dbt_project.yml | awk '{ print $2 }')
         perl -i -pe "s/(schema: |dataset: ).*/\1$value_to_replace/" ~/.dbt/profiles.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # dbt_fivetran_utils v0.4.9
 
-[PR #131](https://github.com/fivetran/dbt_fivetran_utils/pull/131) includes the following updates:
-
 ## Feature Update
 - Added macro `extract_url_parameter` to create special logic for Databricks instances not supported by `dbt_utils.get_url_parameter()`. The macro uses `dbt_utils.get_url_parameter()` for default, non-Databricks targets. See [README](https://github.com/fivetran/dbt_fivetran_utils/blob/releases/v0.4.latest/README.md#extract_url_parameter-source) for more details ([PR #130](https://github.com/fivetran/dbt_fivetran_utils/pull/130)).
 - Made the `try_cast()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#try_cast-source) compatible with SQL Server ([PR #131](https://github.com/fivetran/dbt_fivetran_utils/pull/131)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ PR #<something> includes the following updates:
 
 ## Feature Update
 - Made the `try_cast()` macro compatible with SQL Server.
+- Added a `date_spine()` macro. For non-SQL Server databases, this will simply call `dbt_utils.date_spine()`. For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).
+
 ## Bug Fix
 - Corrected the name of the default version of `try_cast()` from safe_cast to try_cast.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # dbt_fivetran_utils v0.4.9
-PR #<something> includes the following updates:
+[PR #131](https://github.com/fivetran/dbt_fivetran_utils/pull/131) includes the following updates:
 
 ## Feature Update
-- Made the `try_cast()` macro compatible with SQL Server.
-- Added a `date_spine()` macro. For non-SQL Server databases, this will simply call `dbt_utils.date_spine()`. For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).
+- Made the `try_cast()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#try_cast-source) compatible with SQL Server.
+- Made the  `json_parse()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#json_parse-source) compatible with SQL Server.
+- Added a `date_spine()` macro. 
+  - For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). 
+  - For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).
 
 ## Bug Fix
 - Corrected the name of the default version of `try_cast()` from safe_cast to try_cast.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# dbt_fivetran_utils v0.4.9
+PR #<something> includes the following updates:
+
+## Feature Update
+- Made the `try_cast()` macro compatible with SQL Server.
+## Bug Fix
+- Corrected the name of the default version of `try_cast()` from safe_cast to try_cast.
+
 # dbt_fivetran_utils v0.4.8
 [PR #127](https://github.com/fivetran/dbt_fivetran_utils/pull/127) includes the following updates.
 ## Feature Updates

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ vars:
 ### date_spine ([source](macros/date_spine.sql))
 This macro returns the sql required to build a date spine. The spine will include the `start_date` (if it is aligned to the `datepart`), but it will not include the `end_date`.
 
-For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96)
+For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ dispatch:
     - [add\_dbt\_source\_relation (source)](#add_dbt_source_relation-source)
     - [add\_pass\_through\_columns (source)](#add_pass_through_columns-source)
     - [calculated\_fields (source)](#calculated_fields-source)
+    - [date\_spine (source)](#date_spine-source)
     - [drop\_schemas\_automation (source)](#drop_schemas_automation-source)
     - [dummy\_coalesce\_value (source)](#dummy_coalesce_value-source)
     - [fill\_pass\_through\_columns (source)](#fill_pass_through_columns-source)
@@ -81,6 +82,7 @@ dispatch:
     - [remove\_prefix\_from\_columns (source)](#remove_prefix_from_columns-source)
     - [source\_relation (source)](#source_relation-source)
     - [union\_data (source)](#union_data-source)
+      - [Union Data Defined Sources Configuration](#union-data-defined-sources-configuration)
     - [union\_relations (source)](#union_relations-source)
   - [Variable Checks](#variable-checks)
     - [empty\_variable\_warning (source)](#empty_variable_warning-source)
@@ -353,6 +355,26 @@ vars:
 ```
 **Args:**
 * `variable` (required): The variable containing the calculated field `name` and `transform_sql`.
+
+----
+### date_spine ([source](macros/date_spine.sql))
+This macro returns the sql required to build a date spine. The spine will include the `start_date` (if it is aligned to the `datepart`), but it will not include the `end_date`.
+
+For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96)
+
+**Usage:**
+```sql
+{{ fivetran_utils.date_spine(
+    datepart="day",
+    start_date="cast('2019-01-01' as date)",
+    end_date="cast('2020-01-01' as date)"
+   )
+}}
+```
+**Args:**
+* `datepart` (required): The grain at which you would like to create the date spine. 
+* `start_date` (required): The date (inclusive if it is aligned to the `datepart`) at which you'd like the date spine to start.
+* `end_date` (required): The date (excusive) at which you'd like the date spine to end.
 
 ----
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.8'
+version: '0.4.9'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.8'
+version: '0.4.9'
 config-version: 2
 profile: 'integration_tests'
 

--- a/integration_tests/packages_ft_utils_override.yml
+++ b/integration_tests/packages_ft_utils_override.yml
@@ -1,2 +1,0 @@
-packages:
-  - local: ../../../../

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,7 +1,7 @@
-dbt-snowflake>=1.3.0,<1.7.0
-dbt-bigquery>=1.3.0,<1.7.0
-dbt-redshift>=1.3.0,<1.7.0
-dbt-postgres>=1.3.0,<1.7.0
-dbt-spark>=1.3.0,<1.7.0
-dbt-spark[PyHive]>=1.3.0,<1.7.0
-dbt-databricks>=1.6.0,<1.7.0
+dbt-snowflake>=1.3.0,<2.0.0
+dbt-bigquery>=1.3.0,<2.0.0
+dbt-redshift>=1.3.0,<2.0.0
+dbt-postgres>=1.3.0,<2.0.0
+dbt-spark>=1.3.0,<2.0.0
+dbt-spark[PyHive]>=1.3.0,<2.0.0
+dbt-databricks>=1.6.0,<2.0.0

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -1,7 +1,7 @@
-dbt-snowflake>=1.3.0,<2.0.0
-dbt-bigquery>=1.3.0,<2.0.0
-dbt-redshift>=1.3.0,<2.0.0
-dbt-postgres>=1.3.0,<2.0.0
-dbt-spark>=1.3.0,<2.0.0
-dbt-spark[PyHive]>=1.3.0,<2.0.0
-dbt-databricks>=1.6.0,<2.0.0
+dbt-snowflake>=1.3.0,<1.7.0
+dbt-bigquery>=1.3.0,<1.7.0
+dbt-redshift>=1.3.0,<1.7.0
+dbt-postgres>=1.3.0,<1.7.0
+dbt-spark>=1.3.0,<1.7.0
+dbt-spark[PyHive]>=1.3.0,<1.7.0
+dbt-databricks>=1.6.0,<1.7.0

--- a/macros/date_spine.sql
+++ b/macros/date_spine.sql
@@ -102,11 +102,11 @@
 
     {% if execute %}
 
-    {% set results_list = results.columns[0].values() %}
+        {% set results_list = results.columns[0].values() %}
     
     {% else %}
 
-    {% set results_list = [] %}
+        {% set results_list = [] %}
 
     {% endif %}
 

--- a/macros/date_spine.sql
+++ b/macros/date_spine.sql
@@ -1,0 +1,126 @@
+{% macro date_spine(datepart, start_date, end_date) -%}
+
+{{ adapter.dispatch('date_spine', 'fivetran_utils') (datepart, start_date, end_date) }}
+
+{%- endmacro %}
+
+{% macro default__date_spine(datepart, start_date, end_date) %}
+
+    {{ dbt_utils.date_spine(datepart, interval, from_timestamp) }}
+        
+{% endmacro %}
+
+
+{% macro sqlserver__date_spine_sql(datepart, start_date, end_date) %}
+
+    with
+
+    l0 as (
+
+        select c
+        from (select 1 union all select 1) as d(c)
+
+    ),
+    l1 as (
+
+        select
+            1 as c
+        from l0 as a
+        cross join l0 as b
+
+    ),
+
+    l2 as (
+
+        select 1 as c
+        from l1 as a
+        cross join l1 as b
+    ),
+
+    l3 as (
+
+        select 1 as c
+        from l2 as a
+        cross join l2 as b
+    ),
+
+    l4 as (
+
+        select 1 as c
+        from l3 as a
+        cross join l3 as b
+    ),
+
+    l5 as (
+
+        select 1 as c
+        from l4 as a
+        cross join l4 as b
+    ),
+
+    nums as (
+
+        select row_number() over (order by (select null)) as rownum
+        from l5
+    ),
+
+    rawdata as (
+
+        select top ({{dbt.datediff(start_date, end_date, datepart)}}) rownum -1 as n
+        from nums
+        order by rownum
+    ),
+
+    all_periods as (
+
+        select (
+            {{
+                dbt.dateadd(
+                    datepart,
+                    'n',
+                    start_date
+                )
+            }}
+        ) as date_{{datepart}}
+        from rawdata
+    ),
+
+    filtered as (
+
+        select *
+        from all_periods
+        where date_{{datepart}} <= {{ end_date }}
+
+    )
+
+    select * from filtered
+
+{% endmacro %}
+
+
+{% macro sqlserver__date_spine(datepart, start_date, end_date) -%}
+
+    {% set date_spine_query %}
+
+        {{fivetran_utils.sqlserver__date_spine_sql(datepart, start_date, end_date)}} order by 1
+
+    {% endset %}
+
+
+    {% set results = run_query(date_spine_query) %}
+
+    {% if execute %}
+
+    {% set results_list = results.columns[0].values() %}
+    
+    {% else %}
+
+    {% set results_list = [] %}
+
+    {% endif %}
+
+    {%- for date_field in results_list %}
+        select cast('{{ date_field }}' as date) as date_{{datepart}} {{ 'union all ' if not loop.last else '' }}
+    {% endfor -%}
+
+{% endmacro %}

--- a/macros/date_spine.sql
+++ b/macros/date_spine.sql
@@ -10,102 +10,93 @@
         
 {% endmacro %}
 
-
-{% macro sqlserver__date_spine_sql(datepart, start_date, end_date) %}
-
-    with
-
-    l0 as (
-
-        select c
-        from (select 1 union all select 1) as d(c)
-
-    ),
-    l1 as (
-
-        select
-            1 as c
-        from l0 as a
-        cross join l0 as b
-
-    ),
-
-    l2 as (
-
-        select 1 as c
-        from l1 as a
-        cross join l1 as b
-    ),
-
-    l3 as (
-
-        select 1 as c
-        from l2 as a
-        cross join l2 as b
-    ),
-
-    l4 as (
-
-        select 1 as c
-        from l3 as a
-        cross join l3 as b
-    ),
-
-    l5 as (
-
-        select 1 as c
-        from l4 as a
-        cross join l4 as b
-    ),
-
-    nums as (
-
-        select row_number() over (order by (select null)) as rownum
-        from l5
-    ),
-
-    rawdata as (
-
-        select top ({{dbt.datediff(start_date, end_date, datepart)}}) rownum -1 as n
-        from nums
-        order by rownum
-    ),
-
-    all_periods as (
-
-        select (
-            {{
-                dbt.dateadd(
-                    datepart,
-                    'n',
-                    start_date
-                )
-            }}
-        ) as date_{{datepart}}
-        from rawdata
-    ),
-
-    filtered as (
-
-        select *
-        from all_periods
-        where date_{{datepart}} <= {{ end_date }}
-
-    )
-
-    select * from filtered
-
-{% endmacro %}
-
-
 {% macro sqlserver__date_spine(datepart, start_date, end_date) -%}
 
     {% set date_spine_query %}
+        with
 
-        {{fivetran_utils.sqlserver__date_spine_sql(datepart, start_date, end_date)}} order by 1
+        l0 as (
+
+            select c
+            from (select 1 union all select 1) as d(c)
+
+        ),
+        l1 as (
+
+            select
+                1 as c
+            from l0 as a
+            cross join l0 as b
+
+        ),
+
+        l2 as (
+
+            select 1 as c
+            from l1 as a
+            cross join l1 as b
+        ),
+
+        l3 as (
+
+            select 1 as c
+            from l2 as a
+            cross join l2 as b
+        ),
+
+        l4 as (
+
+            select 1 as c
+            from l3 as a
+            cross join l3 as b
+        ),
+
+        l5 as (
+
+            select 1 as c
+            from l4 as a
+            cross join l4 as b
+        ),
+
+        nums as (
+
+            select row_number() over (order by (select null)) as rownum
+            from l5
+        ),
+
+        rawdata as (
+
+            select top ({{dbt.datediff(start_date, end_date, datepart)}}) rownum -1 as n
+            from nums
+            order by rownum
+        ),
+
+        all_periods as (
+
+            select (
+                {{
+                    dbt.dateadd(
+                        datepart,
+                        'n',
+                        start_date
+                    )
+                }}
+            ) as date_{{datepart}}
+            from rawdata
+        ),
+
+        filtered as (
+
+            select *
+            from all_periods
+            where date_{{datepart}} <= {{ end_date }}
+
+        )
+
+        select * from filtered
+        order by 1
 
     {% endset %}
-
 
     {% set results = run_query(date_spine_query) %}
 

--- a/macros/date_spine.sql
+++ b/macros/date_spine.sql
@@ -1,12 +1,12 @@
 {% macro date_spine(datepart, start_date, end_date) -%}
 
-{{ adapter.dispatch('date_spine', 'fivetran_utils') (datepart, start_date, end_date) }}
+{{ return(adapter.dispatch('date_spine', 'fivetran_utils') (datepart, start_date, end_date)) }}
 
 {%- endmacro %}
 
 {% macro default__date_spine(datepart, start_date, end_date) %}
 
-    {{ dbt_utils.date_spine(datepart, interval, from_timestamp) }}
+    {{ dbt_utils.date_spine(datepart, start_date, end_date) }}
         
 {% endmacro %}
 

--- a/macros/json_parse.sql
+++ b/macros/json_parse.sql
@@ -40,3 +40,9 @@
   {{string}} : {%- for s in string_path -%}{% if s is number %}[{{ s }}]{% else %}['{{ s }}']{% endif %}{%- endfor -%}
 
 {% endmacro %}
+
+{% macro sqlserver__json_parse(string, string_path) %}
+
+  json_value({{string}}, '$.{%- for s in string_path -%}{{ s }}{%- if not loop.last -%}.{%- endif -%}{%- endfor -%} ')
+
+{% endmacro %}

--- a/macros/try_cast.sql
+++ b/macros/try_cast.sql
@@ -2,7 +2,7 @@
     {{ adapter.dispatch('try_cast', 'fivetran_utils') (field, type) }}
 {% endmacro %}
 
-{% macro default__safe_cast(field, type) %}
+{% macro default__try_cast(field, type) %}
     {# most databases don't support this function yet
     so we just need to use cast #}
     cast({{field}} as {{type}})

--- a/macros/try_cast.sql
+++ b/macros/try_cast.sql
@@ -50,3 +50,7 @@
 {% macro spark__try_cast(field, type) %}
     try_cast({{field}} as {{type}})
 {% endmacro %}
+
+{% macro sqlserver__try_cast(field, type) %}
+    try_cast({{field}} as {{type}})
+{% endmacro %}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 

### Feature Update
- Made the `try_cast()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#try_cast-source) compatible with SQL Server.
- Made the  `json_parse()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest#json_parse-source) compatible with SQL Server.
- Added a `date_spine()` macro. 
  - For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). 
  - For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).

### Bug Fix
- Corrected the name of the default version of `try_cast()` from safe_cast to try_cast. -- addresses https://github.com/fivetran/dbt_fivetran_utils/issues/122

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->

I ran the fivetran_log package locally using dbt-sqlserver and previously supported adapters.  See fivetran log PR for more detailed validation 

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

the only change that would affect non-sqlserver adapters is the bug fix around try_cast vs safe_cast.  However, because we also have specific dispatches for each adapter, this change would also not affect people on BQ, Snowflake, Redshift, Postgres, or Databricks either. 

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
