### PR TITLE
add sql server quote-wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_fivetran_utils v0.4.11
+
+## Feature Update
+- Added SQL Server logic to the `wrap_in_quotes()` [macro](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest?tab=readme-ov-file#wrap_in_quotes-source) ([PR #138](https://github.com/fivetran/dbt_fivetran_utils/pull/138)).
+
 # dbt_fivetran_utils v0.4.10
 
 ## Bug Fix

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ This macro allows for cross database timestamp difference calculation for BigQue
 
 ----
 ### try_cast ([source](macros/try_cast.sql))
-This macro allows a field to be cast to a specified datatype. If the datatype is incompatible then a `null` value is provided. This macro is compatible with BigQuery, Redshift, Postgres, Snowflake, and Databricks.
+This macro allows a field to be cast to a specified datatype. If the datatype is incompatible then a `null` value is provided. This macro is compatible with BigQuery, Redshift, Postgres, Snowflake, Databricks, and SQL Server.
 > Please note: For Postgres and Redshift destinations the `numeric` datatype is only supported to try_cast.
 **Usage:**
 ```sql
@@ -317,7 +317,7 @@ This macro allows a field to be cast to a specified datatype. If the datatype is
 
 ----
 ### wrap_in_quotes ([source](macros/wrap_in_quotes.sql))
-This macro takes a SQL object (ie database, schema, column) and returns it wrapped in database-appropriate quotes (and casing for Snowflake). 
+This macro takes a SQL object (ie database, schema, column) and returns it wrapped in database-appropriate quotes (and casing for Snowflake). It is compatible with BigQuery, Snowflake, Postgres, Redshift, Databricks, and SQL Server.
 
 **Usage:**
 ```sql
@@ -370,7 +370,7 @@ vars:
 
 ----
 ### fivetran_date_spine ([source](macros/fivetran_date_spine.sql))
-This macro returns the sql required to build a date spine. The spine will include the `start_date` (if it is aligned to the `datepart`), but it will not include the `end_date`.
+This macro returns the sql required to build a date spine. The spine will include the `start_date` (if it is aligned to the `datepart`), but it will not include the `end_date`. It is compatible with BigQuery, Snowflake, Redshift, Postgres, Databricks, and SQL Server.
 
 For non-SQL Server databases, this will simply call [`dbt_utils.date_spine()`](https://github.com/dbt-labs/dbt-utils#date_spine-source). For SQL Server targets, this will manually create a spine, with code heavily leveraged from [`tsql-utils.date_spine()`](https://github.com/dbt-msft/tsql-utils/blob/main/macros/dbt_utils/datetime/date_spine.sql) but [adjusted for recent changes to dbt_utils](https://github.com/dbt-msft/tsql-utils/issues/96).
 

--- a/macros/wrap_in_quotes.sql
+++ b/macros/wrap_in_quotes.sql
@@ -20,3 +20,7 @@
 {%- macro postgres__wrap_in_quotes(object_to_quote)  -%}
     "{{ object_to_quote }}"
 {%- endmacro -%}
+
+{%- macro sqlserver__wrap_in_quotes(object_to_quote)  -%}
+    "{{ object_to_quote }}"
+{%- endmacro -%}


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 

Adds SQLserver logic to the `wrap_in_quotes()` macro. this was necessary as the default logic (using backticks instead of double quotes) did not work with sql server in the Fivetran Platform package

for the time being, i have [excluded](https://github.com/fivetran/dbt_fivetran_log/blob/main/.buildkite/scripts/run_models.sh#L70-L72) the `drop_schemas_automation` run for sqlserver to get around the error. 

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
In Buildkite, where it is called in the `drop_schemas_automation` macro

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->

added sqlserver adapter version of the macro only, and it does not reference any other macros. 

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
