### PR TITLE
Update default branch for fusion 

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,10 +2,10 @@ name: 'fivetran_utils'
 version: '0.1.0'
 config-version: 2
 
-source-paths: ["models"]
+model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]
-data-paths: ["data"]
+seed-paths: ["data"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,14 +2,6 @@ name: 'fivetran_utils'
 version: '0.1.0'
 config-version: 2
 
-model-paths: ["models"]
-analysis-paths: ["analysis"]
-test-paths: ["tests"]
-seed-paths: ["data"]
-macro-paths: ["macros"]
-snapshot-paths: ["snapshots"]
-
-
 vars:
   fivetran_utils:
     dbt_utils_dispatch_list:


### PR DESCRIPTION
This is part of our efforts to support dbt Fusion and is a continuation of https://github.com/fivetran/dbt_fivetran_utils/pull/150

This change is validated by aligning with our current prod version of the [dbt_project.yml](https://github.com/fivetran/dbt_fivetran_utils/blob/v0.4.10/dbt_project.yml)

NO RELEASE WILL COME OF THIS as [we don't maintain](https://github.com/fivetran/dbt_fivetran_utils?tab=readme-ov-file#%EF%B8%8F-warning-%EF%B8%8F) the master branch of this package anymore and instead use branches like [v0.4.latest](https://github.com/fivetran/dbt_fivetran_utils/tree/releases/v0.4.latest?tab=readme-ov-file) instead.

However, very old versions of our packages depend on Fivetran Utils' default branch via git syntax (a couple directly reference `master`). Thus, we will update `master`. 

In related news, we will then finally switch the default branch of this package to be `main`, as we have intended to do so for a long time. We will maintain support for these old releases of our packages. See https://getdbt.slack.com/archives/C01D1R2JLLA/p1749062317419069