### PR TITLE
Add DuckDB percentile dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_fivetran_utils v0.4.12
+
+## Bug Fix
+- Adds DuckDB support to the `percentile` macro by dispatching to DuckDB's aggregate `percentile_cont(...) within group (...)` form.
+
 # dbt_fivetran_utils v0.4.11
 
 [PR #154](https://github.com/fivetran/dbt_fivetran_utils/pull/154) includes the following updates:

--- a/README.md
+++ b/README.md
@@ -239,18 +239,18 @@ This macro allows for cross database use of obtaining the max boolean value of a
 
 ----
 ### percentile ([source](macros/percentile.sql))
-This macro is used to return the designated percentile of a field with cross db functionality. The percentile function stems from percentile_cont across db's. For Snowflake and Redshift this macro uses the window function opposed to the aggregate for percentile. For Postgres, this macro uses the aggregate, as it does not support a percentile window function. Thus, you will need to add a target-dependent `group by` in the query you are calling this macro in.
+This macro is used to return the designated percentile of a field with cross db functionality. The percentile function stems from percentile_cont across db's. For Snowflake and Redshift this macro uses the window function opposed to the aggregate for percentile. For Postgres and DuckDB, this macro uses the aggregate, as they do not support a percentile window function. Thus, you will need to add a target-dependent `group by` in the query you are calling this macro in.
 
 **Usage:**
 ```sql
 select id,
 {{ fivetran_utils.percentile(percentile_field='time_to_close', partition_field='id', percent='0.5') }}
 from your_cte
-{% if target.type == 'postgres' %} group by id {% endif %}
+{% if target.type in ('postgres', 'duckdb') %} group by id {% endif %}
 ```
 **Args:**
 * `percentile_field` (required): Name of the field of which you are determining the desired percentile.
-* `partition_field`  (required): Name of the field you want to partition by to determine the designated percentile. You will need to group by this for Postgres.
+* `partition_field`  (required): Name of the field you want to partition by to determine the designated percentile. You will need to group by this for Postgres and DuckDB.
 * `percent`          (required): The percent necessary for `percentile_cont` to determine the percentile. If you want to find the median, you will input `0.5` for the percent. 
 
 ----

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
 name: 'fivetran_utils'
-version: '0.4.11'
+version: '0.4.12'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<3.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'fivetran_utils_integration_tests'
-version: '0.4.11'
+version: '0.4.12'
 config-version: 2
 profile: 'integration_tests'
 

--- a/macros/percentile.sql
+++ b/macros/percentile.sql
@@ -44,6 +44,15 @@
 
 {% endmacro %}
 
+{% macro duckdb__percentile(percentile_field, partition_field, percent)  %}
+
+    percentile_cont(
+        {{ percent }} )
+        within group ( order by {{ percentile_field }} )
+    /* have to group by partition field */
+
+{% endmacro %}
+
 {% macro spark__percentile(percentile_field, partition_field, percent)  %}
 
     percentile( 


### PR DESCRIPTION
**What change does this PR introduce?** 
<!--- Describe what you did and why. --> 
Adds a DuckDB-specific dispatch implementation for `fivetran_utils.percentile`.

DuckDB supports `percentile_cont(...) within group (order by ...)` as an aggregate, but does not support the Redshift-style `percentile_cont(...) within group (...) over (...)` window form used by the
  default macro implementation.

This change mirrors the existing Postgres aggregate contract: callers using DuckDB must group by the partition field.

**If this PR introduces a new macro, how did you test the new macro?** 
<!--- Describe how you tested the new macro code. -->
Tested against DuckDB.

Validated that:
  - `percentile_cont(0.5) within group (order by x)` succeeds and returns the expected median.
  - The default windowed form, `percentile_cont(...) within group (...) over (partition by ...)`, fails in DuckDB with `Catalog Error: Aggregate Function with name percentile_cont does not exist!`.
  - A grouped median query using the same aggregate pattern returns expected per-group medians.

Also ran `git diff --check`.

**If this PR introduces a modification to an existing macro, which packages is the macro currently present in and what steps were taken to test compatibility across packages?** 
<!--- List the packages the macro is in and how you tested the changes. -->
This adds a new adapter dispatch macro, `duckdb__percentile`, inside `fivetran_utils.percentile`.

Existing dispatch implementations are unchanged:
  - `default__percentile`
  - `redshift__percentile`
  - `bigquery__percentile`
  - `postgres__percentile`
  - `spark__percentile`

Compatibility check:
  - The change is scoped to `target.type == 'duckdb'`.
  - Existing adapters continue to dispatch to their current implementations.
  - The README was updated to document that DuckDB follows the same aggregate and `group by` contract as Postgres.

**Did you update the README to reflect the macro addition/modifications?** 
<!--- Mark yes or no. If no, provide a reason. -->
- [x] Yes
- [ ] No (provide further explanation)
